### PR TITLE
fix: lock scroll in LogsSummary when a Hot Post is selected

### DIFF
--- a/src/features/moneylog/components/LogsSummary/LogsSummary.tsx
+++ b/src/features/moneylog/components/LogsSummary/LogsSummary.tsx
@@ -1,76 +1,79 @@
-import { useEffect, useMemo, useState } from "react"
-import { getFunctions, httpsCallable, connectFunctionsEmulator } from "firebase/functions"
-import { getApp } from "firebase/app"
-import { doc, onSnapshot } from "firebase/firestore"
-import { db } from "@/config/firebase-config"
-import { useCurrentUser } from "@/contexts"
-import { Group, LogPost } from "@/types/user"
+import { useEffect, useMemo, useState } from "react";
+import cx from "classnames";
+import { getFunctions, httpsCallable, connectFunctionsEmulator } from "firebase/functions";
+import { getApp } from "firebase/app";
+import { doc, onSnapshot } from "firebase/firestore";
+import { db } from "@/config/firebase-config";
+import { useCurrentUser } from "@/contexts";
+import { Group, LogPost } from "@/types/user";
 
-import { useGetComments } from "@/hooks/useGetLogPostComments"
-import { FullUserData, useGetGroupUsers } from "@/hooks/useGetGroupUsers"
-import { useGroupAnalytics } from "./hooks/useGroupAnalytics"
+import { useGetComments } from "@/hooks/useGetLogPostComments";
+import { useDisableScroll } from "@/hooks/useDisableScroll";
+import { FullUserData, useGetGroupUsers } from "@/hooks/useGetGroupUsers";
+import { useGroupAnalytics } from "./hooks/useGroupAnalytics";
 
-import Loader from "@/features/layout/components/Loader"
-import SpendingInsights from "./SpendingInsights"
-import HotPosts from "./HotPosts"
-import LogPostComments from "../LogPosts/LogPostComments"
+import Loader from "@/features/layout/components/Loader";
+import SpendingInsights from "./SpendingInsights";
+import HotPosts from "./HotPosts";
+import LogPostComments from "../LogPosts/LogPostComments";
 
-import './styles.scss'
-import CustomDropdown, { DropdownOption } from "@/components/CustomDropdown"
-import Button from "@/components/Button"
+import "./styles.scss";
+import CustomDropdown, { DropdownOption } from "@/components/CustomDropdown";
+import Button from "@/components/Button";
 
 interface LogsSummaryProps {
-  group: Group
-  logPosts: Array<LogPost>
-  groupMembers: FullUserData[]
+  group: Group;
+  logPosts: Array<LogPost>;
+  groupMembers: FullUserData[];
 }
 
 interface ProcessingState {
-  step: string
-  percentage: number
-  isComplete: boolean
+  step: string;
+  percentage: number;
+  isComplete: boolean;
 }
 
 const LogsSummary = ({ group, groupMembers, logPosts }: LogsSummaryProps) => {
-  const { user: loggedInUser } = useCurrentUser()
+  const { user: loggedInUser } = useCurrentUser();
 
-  const [processingState, setProcessingState] = useState<ProcessingState | null>(null)
-  const [analyticsError, setAnalyticsError] = useState<string | null>(null)
-  const [hasStartedProcessing, setHasStartedProcessing] = useState<boolean>(false)
+  const [processingState, setProcessingState] = useState<ProcessingState | null>(null);
+  const [analyticsError, setAnalyticsError] = useState<string | null>(null);
+  const [hasStartedProcessing, setHasStartedProcessing] = useState<boolean>(false);
 
-  const groupAnalytics = useGroupAnalytics(logPosts, group, groupMembers)
+  const groupAnalytics = useGroupAnalytics(logPosts, group, groupMembers);
 
-  const { users: members } = useGetGroupUsers(group.id)
+  const { users: members } = useGetGroupUsers(group.id);
   const memberIdToMembers = useMemo(() => {
-    const map = new Map<string, FullUserData>()
+    const map = new Map<string, FullUserData>();
     members.forEach((m) => {
-      map.set(m.id, m)
-    })
-    return map
-  }, [members])
+      map.set(m.id, m);
+    });
+    return map;
+  }, [members]);
 
-  const [otherLogs, setOtherLogs] = useState<LogPost[] | null>(null)
+  const [otherLogs, setOtherLogs] = useState<LogPost[] | null>(null);
 
   // Firebase Functions setup
-  const app = getApp()
-  const functions = getFunctions(app)
+  const app = getApp();
+  const functions = getFunctions(app);
 
   // Connect to emulator if in development
-  if (window.location.hostname === 'localhost') {
-    connectFunctionsEmulator(functions, 'localhost', 5001)
+  if (window.location.hostname === "localhost") {
+    connectFunctionsEmulator(functions, "localhost", 5001);
   }
 
-  const processAnalytics = httpsCallable(functions, 'processGroupAnalytics')
+  const processAnalytics = httpsCallable(functions, "processGroupAnalytics");
 
   const myLogs = useMemo(() => {
-    return logPosts.filter(logPost => logPost.author.id === loggedInUser?.id)
-  }, [logPosts, loggedInUser?.id])
+    return logPosts.filter((logPost) => logPost.author.id === loggedInUser?.id);
+  }, [logPosts, loggedInUser?.id]);
 
   const handleSelectTestOtherLogs = (userId: string) => {
-    setOtherLogs(logPosts.filter(logPost => logPost.author.id === userId))
-  }
+    setOtherLogs(logPosts.filter((logPost) => logPost.author.id === userId));
+  };
 
-  const [selectedPost, setSelectedPost] = useState<LogPost | null>(null)
+  const [selectedPost, setSelectedPost] = useState<LogPost | null>(null);
+  useDisableScroll(!!selectedPost);
 
   const {
     data: comments,
@@ -79,79 +82,78 @@ const LogsSummary = ({ group, groupMembers, logPosts }: LogsSummaryProps) => {
   } = useGetComments({
     logPostId: selectedPost?.id ?? null,
     forceFresh: true,
-  })
+  });
 
   // Check if group is archived and needs analytics processing
   const isArchivedGroup = useMemo(() => {
-    const now = new Date()
-    const groupEndDate = new Date(group.end.seconds * 1000)
-    return groupEndDate < now
-  }, [group.end])
+    const now = new Date();
+    const groupEndDate = new Date(group.end.seconds * 1000);
+    return groupEndDate < now;
+  }, [group.end]);
 
-  const hasAnalytics = Boolean(group.analytics?.isCalculated)
-  const needsProcessing = isArchivedGroup && !hasAnalytics && !hasStartedProcessing
+  const hasAnalytics = Boolean(group.analytics?.isCalculated);
+  const needsProcessing = isArchivedGroup && !hasAnalytics && !hasStartedProcessing;
 
   // Effect to handle analytics processing and progress tracking
   useEffect(() => {
-    if (!needsProcessing || !loggedInUser) return
+    if (!needsProcessing || !loggedInUser) return;
 
     // Prevent multiple processing attempts
-    setHasStartedProcessing(true)
+    setHasStartedProcessing(true);
 
-    let unsubscribe: (() => void) | null = null
+    let unsubscribe: (() => void) | null = null;
 
     const startProcessing = async () => {
       try {
         // Set up listener for progress updates BEFORE starting processing
-        const processingDocRef = doc(db, 'processing', group.id)
+        const processingDocRef = doc(db, "processing", group.id);
         unsubscribe = onSnapshot(processingDocRef, (doc) => {
           if (doc.exists()) {
-            const data = doc.data() as ProcessingState
-            setProcessingState(data)
+            const data = doc.data() as ProcessingState;
+            setProcessingState(data);
 
             // If processing is complete, we can stop listening
             if (data.isComplete) {
               setTimeout(() => {
-                setProcessingState(null)
-                unsubscribe?.()
+                setProcessingState(null);
+                unsubscribe?.();
                 // Don't reset hasStartedProcessing here - let the group data update handle it
-              }, 2000) // Show "Complete!" for 2 seconds
+              }, 2000); // Show "Complete!" for 2 seconds
             }
           }
-        })
+        });
 
         // Start the analytics processing
-        await processAnalytics({ groupId: group.id, groupEnd: group.end })
-
+        await processAnalytics({ groupId: group.id, groupEnd: group.end });
       } catch (error) {
-        console.error('Failed to start analytics processing:', error)
-        setAnalyticsError(error instanceof Error ? error.message : 'Unknown error')
-        setProcessingState(null)
+        console.error("Failed to start analytics processing:", error);
+        setAnalyticsError(error instanceof Error ? error.message : "Unknown error");
+        setProcessingState(null);
         // setHasStartedProcessing(false) // Reset on error so user can retry
-        unsubscribe?.()
+        unsubscribe?.();
       }
-    }
+    };
 
-    startProcessing()
+    void startProcessing();
 
     // Cleanup function
     return () => {
-      unsubscribe?.()
-    }
-  }, [needsProcessing, loggedInUser, group.id, processAnalytics])
+      unsubscribe?.();
+    };
+  }, [needsProcessing, loggedInUser, group.id, group.end, processAnalytics]);
 
   // Reset processing state when analytics become available
   useEffect(() => {
     if (hasAnalytics && hasStartedProcessing) {
-      setHasStartedProcessing(false)
-      setProcessingState(null)
-      setAnalyticsError(null)
+      setHasStartedProcessing(false);
+      setProcessingState(null);
+      setAnalyticsError(null);
     }
-  }, [hasAnalytics, hasStartedProcessing])
+  }, [hasAnalytics, hasStartedProcessing]);
 
-  const handleOpenComments = (post: LogPost, hasUnreadComments: boolean) => {
-    setSelectedPost(post)
-  }
+  const handleOpenComments = (post: LogPost, _hasUnreadComments: boolean) => {
+    setSelectedPost(post);
+  };
 
   // Show loading state while processing
   if (processingState) {
@@ -160,18 +162,16 @@ const LogsSummary = ({ group, groupMembers, logPosts }: LogsSummaryProps) => {
         <h2>Preparing insights for {group.title}</h2>
         <div className="Window">
           <h3>📊 Processing analytics...</h3>
-          <div style={{ padding: '2rem', textAlign: 'center' }}>
-            <p style={{ marginBottom: '1rem', fontSize: '1.1em' }}>
-              {processingState.step}
-            </p>
+          <div style={{ padding: "2rem", textAlign: "center" }}>
+            <p style={{ marginBottom: "1rem", fontSize: "1.1em" }}>{processingState.step}</p>
             <Loader progress={processingState.percentage} />
-            <p style={{ marginTop: '1rem', color: '#666', fontSize: '0.9em' }}>
+            <p style={{ marginTop: "1rem", color: "#666", fontSize: "0.9em" }}>
               This only happens once when the group is first archived
             </p>
           </div>
         </div>
       </div>
-    )
+    );
   }
 
   // Show error state if analytics processing failed
@@ -198,13 +198,13 @@ const LogsSummary = ({ group, groupMembers, logPosts }: LogsSummaryProps) => {
           </div>
         )}
       </div>
-    )
+    );
   }
 
   // Normal rendering (either with cached analytics or real-time calculation)
   return (
     <>
-      <div className="LogsSummary">
+      <div className={cx("LogsSummary", { "disable-scroll": !!selectedPost })}>
         <h2>Insights for {group.title}</h2>
 
         {/*{hasAnalytics && (
@@ -213,29 +213,31 @@ const LogsSummary = ({ group, groupMembers, logPosts }: LogsSummaryProps) => {
           </div>
         )}*/}
 
-        {loggedInUser?.email === 'cui.naomi@gmail.com' && (
+        {loggedInUser?.email === "cui.naomi@gmail.com" && (
           <div>
             <CustomDropdown
-              options={group.members.map(m => ({
+              options={group.members.map((m) => ({
                 value: m.id,
                 label: memberIdToMembers.get(m.id)?.displayName ?? m.id,
               }))}
               onSelect={(option: DropdownOption) => {
-                handleSelectTestOtherLogs(option.value)
+                handleSelectTestOtherLogs(option.value);
               }}
             >
-              <Button
-                text="Select user"
-              />
+              <Button text="Select user" />
             </CustomDropdown>
           </div>
         )}
 
-        {loggedInUser?.email === 'cui.naomi@gmail.com' && otherLogs && otherLogs?.length > 0 && (
+        {loggedInUser?.email === "cui.naomi@gmail.com" && otherLogs && otherLogs?.length > 0 && (
           <div className="Window">
             <h3>💰 {memberIdToMembers.get(otherLogs?.[0].author.id)?.displayName}'s spending</h3>
 
-            <SpendingInsights user={memberIdToMembers.get(otherLogs?.[0].author.id)} logPosts={otherLogs} group={group}>
+            <SpendingInsights
+              user={memberIdToMembers.get(otherLogs?.[0].author.id) ?? {}}
+              logPosts={otherLogs}
+              group={group}
+            >
               <SpendingInsights.TotalText>
                 This user spent a <strong>total of</strong>
               </SpendingInsights.TotalText>
@@ -252,9 +254,7 @@ const LogsSummary = ({ group, groupMembers, logPosts }: LogsSummaryProps) => {
                 Here are this user's average <strong>spending patterns</strong>:
               </SpendingInsights.AveragesText>
 
-              <SpendingInsights.WeekendWeekdayText>
-                {''}
-              </SpendingInsights.WeekendWeekdayText>
+              <SpendingInsights.WeekendWeekdayText>{""}</SpendingInsights.WeekendWeekdayText>
 
               <SpendingInsights.NoSpendDaysText>
                 This user had <strong>no spending</strong> on
@@ -267,11 +267,14 @@ const LogsSummary = ({ group, groupMembers, logPosts }: LogsSummaryProps) => {
           </div>
         )}
 
-
         {loggedInUser && (
           <div className="Window">
             <h3>💰 {loggedInUser?.displayName}'s spending</h3>
-            <SpendingInsights user={memberIdToMembers.get(loggedInUser.id)} logPosts={myLogs} group={group}>
+            <SpendingInsights
+              user={memberIdToMembers.get(loggedInUser.id) ?? {}}
+              logPosts={myLogs}
+              group={group}
+            >
               <SpendingInsights.TotalText>
                 You spent a <strong>total of</strong>
               </SpendingInsights.TotalText>
@@ -288,9 +291,7 @@ const LogsSummary = ({ group, groupMembers, logPosts }: LogsSummaryProps) => {
                 Here are your average <strong>spending patterns</strong>:
               </SpendingInsights.AveragesText>
 
-              <SpendingInsights.WeekendWeekdayText>
-                {''}
-              </SpendingInsights.WeekendWeekdayText>
+              <SpendingInsights.WeekendWeekdayText>{""}</SpendingInsights.WeekendWeekdayText>
 
               <SpendingInsights.NoSpendDaysText>
                 You logged <strong>no spending</strong> on
@@ -305,7 +306,7 @@ const LogsSummary = ({ group, groupMembers, logPosts }: LogsSummaryProps) => {
 
         <div className="Window">
           <h3>💸 group spending</h3>
-          <SpendingInsights logPosts={logPosts} group={group}>
+          <SpendingInsights user={{}} logPosts={logPosts} group={group}>
             <SpendingInsights.TotalText>
               The group spent a <strong>total of</strong>
             </SpendingInsights.TotalText>
@@ -342,9 +343,14 @@ const LogsSummary = ({ group, groupMembers, logPosts }: LogsSummaryProps) => {
           />
         )}
       </div>
-      {selectedPost && <div className="LogPostComments__handler handler" onClick={() => setSelectedPost(null)}></div>}
+      {selectedPost && (
+        <div
+          className="LogPostComments__handler handler"
+          onClick={() => setSelectedPost(null)}
+        ></div>
+      )}
     </>
-  )
-}
+  );
+};
 
-export default LogsSummary
+export default LogsSummary;


### PR DESCRIPTION
LogsSummary managed its own selectedPost state but never called useDisableScroll or applied disable-scroll to its scroll container. Wheel events over the selected post propagated up to .LogsSummary (overflow-y: auto) and scrolled it freely while comments were open.

- Add useDisableScroll(!!selectedPost) before early returns so the html element is locked whenever a post is selected
- Apply disable-scroll class to .LogsSummary (the scroll container) when selectedPost is set, mirroring how LogPosts locks .LogPosts__posts
- Fix pre-existing lint/type errors surfaced by the linter: missing group.end dep, unused hasUnreadComments param, FullUserData|undefined not assignable to Partial<FullUserData>, missing user prop, floating promise

Addresses https://github.com/naobot/moneylogs/issues/64