### PR TITLE
feat: global error snackbar with Sentry integration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,20 @@
-import { PropsWithChildren, useEffect } from 'react'
-import { BrowserRouter as Router, Route, Routes, NavigateProps, Navigate } from 'react-router-dom'
-import { useAuthState } from 'react-firebase-hooks/auth'
-// @ts-ignore
-import { auth } from './config/firebase-config'
-import Layout from './features/layout/Layout'
-import GlobalErrorHandler from './utils/errorHandler'
-import { useToast } from './hooks/useToast'
+import { PropsWithChildren, useEffect } from "react";
+import { BrowserRouter as Router, Route, Routes, NavigateProps, Navigate } from "react-router-dom";
+import { useAuthState } from "react-firebase-hooks/auth";
+import { auth } from "./config/firebase-config";
+import Layout from "./features/layout/Layout";
+import GlobalErrorHandler from "./utils/errorHandler";
+import { useToastContext } from "./hooks/useToastContext";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 
-import { Auth } from './pages/auth'
-import { Home } from './pages/home'
-import { UserSettings } from './pages/me'
-import { CreateNewLog } from './pages/create'
-import { GroupPage } from './pages/group'
-import { About } from './pages/about'
+import { Auth } from "./pages/auth";
+import { Home } from "./pages/home";
+import { UserSettings } from "./pages/me";
+import { CreateNewLog } from "./pages/create";
+import { GroupPage } from "./pages/group";
+import { About } from "./pages/about";
 
-import { ToastContainer } from './components/ToastContainer'
-
-import './App.scss'
+import "./App.scss";
 
 export const CheckAuth = ({
   children,
@@ -24,47 +22,64 @@ export const CheckAuth = ({
   ...props
 }: PropsWithChildren<
   Partial<NavigateProps> & {
-    auth?: boolean
+    auth?: boolean;
   }
 >) => {
-  const [user, loading] = useAuthState(auth)
+  const [user, loading] = useAuthState(auth);
 
-  if (loading) return <div>Loading...</div>
+  if (loading) return <div>Loading...</div>;
 
   if (!user && requireAuth) {
-    return <Navigate to={'/login'} replace {...props} />
+    return <Navigate to={"/login"} replace {...props} />;
   }
 
-  return <>{children}</>
-}
+  return <>{children}</>;
+};
 
 const App = () => {
-  const { toasts, showToast, removeToast } = useToast()
+  const { showToast } = useToastContext();
 
   useEffect(() => {
-    const errorHandler = GlobalErrorHandler.getInstance()
-    errorHandler.initialize(showToast)
-  }, [showToast])
+    GlobalErrorHandler.getInstance().initialize(showToast);
+  }, [showToast]);
 
   return (
-    <>
-      <Router>
-        <Layout>
+    <Router>
+      <Layout>
+        <ErrorBoundary>
           <Routes>
-            <Route path='/login' element={<Auth />} />
-            <Route path='/about' element={<About />} />
-            <Route path='/create' element={<CreateNewLog />} />
-            <Route path='/' element={<CheckAuth><Home /></CheckAuth>} />
-            <Route path='/me' element={<CheckAuth><UserSettings /></CheckAuth>} />
-
-            <Route path='/g/:groupId' element={<CheckAuth><GroupPage /></CheckAuth>} />
+            <Route path="/login" element={<Auth />} />
+            <Route path="/about" element={<About />} />
+            <Route path="/create" element={<CreateNewLog />} />
+            <Route
+              path="/"
+              element={
+                <CheckAuth>
+                  <Home />
+                </CheckAuth>
+              }
+            />
+            <Route
+              path="/me"
+              element={
+                <CheckAuth>
+                  <UserSettings />
+                </CheckAuth>
+              }
+            />
+            <Route
+              path="/g/:groupId"
+              element={
+                <CheckAuth>
+                  <GroupPage />
+                </CheckAuth>
+              }
+            />
           </Routes>
+        </ErrorBoundary>
+      </Layout>
+    </Router>
+  );
+};
 
-          <ToastContainer toasts={toasts} onRemove={removeToast} />
-        </Layout>
-      </Router>
-    </>
-  )
-}
-
-export default App
+export default App;

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,56 +1,37 @@
-import { Component, ErrorInfo, ReactNode } from 'react'
-import GlobalErrorHandler from '../utils/errorHandler'
+import { Component, ErrorInfo, ReactNode } from "react";
+import GlobalErrorHandler from "../utils/errorHandler";
 
 interface Props {
-  children: ReactNode
-  showToast: (message: string) => void
+  children: ReactNode;
 }
 
 interface State {
-  hasError: boolean
-  error?: Error
+  hasError: boolean;
 }
 
 export class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
-    super(props)
-    this.state = { hasError: false }
+    super(props);
+    this.state = { hasError: false };
   }
 
-  static getDerivedStateFromError(error: Error): State {
-    return { hasError: true, error }
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
   }
 
-  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    const errorHandler = GlobalErrorHandler.getInstance()
-
-    // Create a combined error message with component stack
-    const enhancedError = new Error(
-      `${error.message}\n\nComponent Stack: ${errorInfo.componentStack}`
-    )
-
-    errorHandler.reportError(enhancedError, 'react-boundary', this.props.showToast)
+  componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
+    GlobalErrorHandler.getInstance().reportError(error, "react-boundary");
   }
 
   render() {
     if (this.state.hasError) {
       return (
-        <div className="error-boundary">
-          <h2>Oops! Something went wrong</h2>
-          <p>
-            We've been notified of this issue. Please refresh the page or contact support
-            if the problem persists.
-          </p>
-          <button
-            onClick={() => window.location.reload()}
-            className="retry-button"
-          >
-            Refresh Page
-          </button>
+        <div className="ErrorBoundary">
+          <p>Something went wrong. Please refresh the page.</p>
+          <button onClick={() => window.location.reload()}>Refresh</button>
         </div>
-      )
+      );
     }
-
-    return this.props.children
+    return this.props.children;
   }
 }

--- a/src/components/Snackbar.scss
+++ b/src/components/Snackbar.scss
@@ -1,0 +1,52 @@
+@keyframes snackbar-enter {
+  from {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.Snackbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1100;
+  pointer-events: none;
+
+  &__item {
+    pointer-events: auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1em;
+    width: 100%;
+    padding: 0.5em 1em;
+    background-color: var(--c-black);
+    color: #fff;
+    animation: snackbar-enter 0.2s ease-out;
+  }
+
+  &__message {
+    font-size: 0.75rem;
+    letter-spacing: 0.02em;
+  }
+
+  &__close {
+    background: none;
+    border: none;
+    color: rgba(255, 255, 255, 0.5);
+    cursor: pointer;
+    font-size: 0.9rem;
+    padding: 0;
+    line-height: 1;
+    flex-shrink: 0;
+
+    &:hover {
+      color: #fff;
+    }
+  }
+}

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -1,34 +1,28 @@
+import "./Snackbar.scss";
+
 interface Toast {
-  id: string
-  message: string
-  timestamp: Date
+  id: string;
+  message: string;
+  timestamp: Date;
 }
 
-interface ToastContainerProps {
-  toasts: Toast[]
-  onRemove: (id: string) => void
+interface SnackbarProps {
+  toasts: Toast[];
+  onRemove: (id: string) => void;
 }
 
-export const ToastContainer: React.FC<ToastContainerProps> = ({ toasts, onRemove }) => {
-  if (toasts.length === 0) return null
+export const Snackbar = ({ toasts, onRemove }: SnackbarProps) => {
+  if (toasts.length === 0) return null;
+  const toast = toasts[toasts.length - 1];
 
   return (
-    <div className="toast-container">
-      {toasts.map(toast => (
-        <div key={toast.id} className="toast error-toast">
-          <div className="toast-content">
-            <span className="toast-icon">⚠️</span>
-            <span className="toast-message">{toast.message}</span>
-          </div>
-          <button
-            className="toast-close"
-            onClick={() => onRemove(toast.id)}
-            aria-label="Close notification"
-          >
-            ×
-          </button>
-        </div>
-      ))}
+    <div className="Snackbar">
+      <div key={toast.id} className="Snackbar__item">
+        <span className="Snackbar__message">{toast.message}</span>
+        <button className="Snackbar__close" onClick={() => onRemove(toast.id)} aria-label="Dismiss">
+          ✕
+        </button>
+      </div>
     </div>
-  )
-}
+  );
+};

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -1,0 +1,15 @@
+import { PropsWithChildren } from "react";
+import { useToast } from "@/hooks/useToast";
+import { Snackbar } from "@/components/ToastContainer";
+import { ToastContext } from "./toastContextValue";
+
+export const ToastProvider = ({ children }: PropsWithChildren) => {
+  const { toasts, showToast, removeToast } = useToast();
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <Snackbar toasts={toasts} onRemove={removeToast} />
+    </ToastContext.Provider>
+  );
+};

--- a/src/contexts/toastContextValue.ts
+++ b/src/contexts/toastContextValue.ts
@@ -1,0 +1,7 @@
+import { createContext } from "react";
+
+export interface ToastContextValue {
+  showToast: (message?: string) => void;
+}
+
+export const ToastContext = createContext<ToastContextValue | null>(null);

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,33 +1,28 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback } from "react";
 
 interface Toast {
-  id: string
-  message: string
-  timestamp: Date
+  id: string;
+  message: string;
+  timestamp: Date;
 }
+
+const DISMISS_MS = 4000;
 
 export const useToast = () => {
-  const [toasts, setToasts] = useState<Toast[]>([])
+  const [toasts, setToasts] = useState<Toast[]>([]);
 
-  const showToast = useCallback((message: string) => {
-    const id = Date.now().toString()
-    const newToast: Toast = {
-      id,
-      message,
-      timestamp: new Date()
-    }
+  const showToast = useCallback((message: string = "An error has occurred") => {
+    const id = Date.now().toString();
+    setToasts([{ id, message, timestamp: new Date() }]);
 
-    setToasts(prev => [...prev, newToast])
-
-    // Auto-remove after 5 seconds
     setTimeout(() => {
-      setToasts(prev => prev.filter(toast => toast.id !== id))
-    }, 5000)
-  }, [])
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, DISMISS_MS);
+  }, []);
 
   const removeToast = useCallback((id: string) => {
-    setToasts(prev => prev.filter(toast => toast.id !== id))
-  }, [])
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
 
-  return { toasts, showToast, removeToast }
-}
+  return { toasts, showToast, removeToast };
+};

--- a/src/hooks/useToastContext.ts
+++ b/src/hooks/useToastContext.ts
@@ -1,0 +1,8 @@
+import { useContext } from "react";
+import { ToastContext } from "@/contexts/toastContextValue";
+
+export const useToastContext = () => {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToastContext must be used within ToastProvider");
+  return ctx;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,14 +1,34 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
-import './utils/configuredDayjs'
-import { CurrentUserProvider } from './contexts/CurrentUserContext'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import * as Sentry from "@sentry/react";
+import "./index.css";
+import App from "./App";
+import "./utils/configuredDayjs";
+import { CurrentUserProvider } from "./contexts/CurrentUserContext";
+import { ToastProvider } from "./contexts/ToastContext";
 
-createRoot(document.getElementById('root')!).render(
+Sentry.init({
+  dsn: "https://0e984f575ce18cc4c1dc79cfa56e845e@o4511585490239488.ingest.us.sentry.io/4511585495744512",
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/react/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: []
+  },
+  integrations: [Sentry.replayIntegration()],
+  // Session Replay
+  replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
+  replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.,
+  // Enable logs to be sent to Sentry
+  enableLogs: true,
+});
+
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <CurrentUserProvider>
-      <App />
+      <ToastProvider>
+        <App />
+      </ToastProvider>
     </CurrentUserProvider>
   </StrictMode>,
-)
+);

--- a/src/pages/me/index.tsx
+++ b/src/pages/me/index.tsx
@@ -1,70 +1,73 @@
-import cx from 'classnames'
-import { useEffect, useMemo, useState } from "react"
-import { useTimezoneSelect, allTimezones } from "react-timezone-select"
+import cx from "classnames";
+import { useEffect, useMemo, useState } from "react";
+import { useTimezoneSelect, allTimezones } from "react-timezone-select";
 
-import { useCurrentUser } from '@/contexts'
+import { useCurrentUser } from "@/contexts";
 
-import { useGetCurrentGroups } from '@/hooks/useGetCurrentGroups'
-import { useMutation } from '@/hooks/useFirebase'
-import { useUserQuery } from '@/hooks/useUserQuery'
-import { useReadTracking } from '@/hooks/useReadTracking'
+import { useGetCurrentGroups } from "@/hooks/useGetCurrentGroups";
+import { useMutation } from "@/hooks/useFirebase";
+import { useUserQuery } from "@/hooks/useUserQuery";
+import { useReadTracking } from "@/hooks/useReadTracking";
 
-import Button from "@/components/Button"
-import ControlledInput from "@/components/ControlledInput"
+import Button from "@/components/Button";
+import ControlledInput from "@/components/ControlledInput";
 
 import "./me.scss";
-import GroupArchive from '@/features/moneylog/components/GroupArchive'
-import dayjs from 'dayjs'
-
+import GroupArchive from "@/features/moneylog/components/GroupArchive";
+import dayjs from "dayjs";
+import * as Sentry from "@sentry/react";
 
 export const UserSettings = () => {
-  const { allGroups, isSuccess, isLoading, isError } = useGetCurrentGroups()
+  const { allGroups, isSuccess } = useGetCurrentGroups();
 
-  const { trackUserAction } = useReadTracking()
-  const { user } = useCurrentUser()
-  const { options, parseTimezone } = useTimezoneSelect({ labelStyle: 'original', timezones: allTimezones })
+  const { trackUserAction } = useReadTracking();
+  const { user } = useCurrentUser();
+  const { options, parseTimezone } = useTimezoneSelect({
+    labelStyle: "original",
+    timezones: allTimezones,
+  });
 
-  const [newDisplayName, setNewDisplayName] = useState('')
-  const [newDisplayLocation, setNewDisplayLocation] = useState('')
-  const [newTimezone, setNewTimezone] = useState<string>()
+  const [newDisplayName, setNewDisplayName] = useState("");
+  const [newDisplayLocation, setNewDisplayLocation] = useState("");
+  const [newTimezone, setNewTimezone] = useState<string>();
 
   const isSubmittable = useMemo(() => {
-    return !!user?.userId && !!newTimezone
-  }, [user?.userId, newTimezone])
+    return !!user?.userId && !!newTimezone;
+  }, [user?.userId, newTimezone]);
 
-  const { updateUserProfile } = useUserQuery()
+  const { updateUserProfile } = useUserQuery();
 
   const { mutate: updateUserInfo, isLoading: createPending } = useMutation(
     async (userData: {
-      userId: string
-      displayName: string
-      displayLocation?: string
-      timezone: string
+      userId: string;
+      displayName: string;
+      displayLocation?: string;
+      timezone: string;
     }) => {
-      await updateUserProfile.mutate(userData)
+      await updateUserProfile.mutate(userData);
 
-      trackUserAction('update_user_profile', {
+      trackUserAction("update_user_profile", {
         user_id: user?.id,
-      })
+      });
 
-      return
-    }
-  )
+      return;
+    },
+  );
 
   useEffect(() => {
     if (user?.displayName) {
-      setNewDisplayName(user?.displayName)
+      setNewDisplayName(user?.displayName);
     }
     if (user?.displayLocation) {
-      setNewDisplayLocation(user?.displayLocation)
+      setNewDisplayLocation(user?.displayLocation);
     }
     if (user?.timezone) {
-      setNewTimezone(user?.timezone)
+      setNewTimezone(user?.timezone);
     }
-  }, [user])
+  }, [user]);
 
   const handleUpdateUserInfo = async () => {
-    if (!user?.userId || !newTimezone) return
+    if (!user?.userId || !newTimezone) return;
 
     try {
       await updateUserInfo({
@@ -72,57 +75,58 @@ export const UserSettings = () => {
         displayName: newDisplayName,
         displayLocation: newDisplayLocation ?? undefined,
         timezone: newTimezone,
-      })
+      });
 
-      console.log('Successfully updated user info')
+      console.log("Successfully updated user info");
     } catch (err) {
-      console.error('Failed to update user info:', err)
+      console.error("Failed to update user info:", err);
       // Error state is handled by useMutation
     }
-  }
+  };
 
   return (
     <div className="Window UserSettings">
-      <div className="Window__heading">
-        {user?.displayName && <h2>hi {user?.displayName}</h2>}
-      </div>
+      <div className="Window__heading">{user?.displayName && <h2>hi {user?.displayName}</h2>}</div>
 
       <div className="UserSettings__form">
         <ControlledInput
-          onChange={(e: any) => setNewDisplayName(e?.target?.value)}
+          onChange={(e) => setNewDisplayName((e.target as HTMLInputElement).value)}
           label="Display name"
           value={newDisplayName}
         />
 
         <ControlledInput
-          onChange={(e: any) => setNewDisplayLocation(e?.target?.value)}
+          onChange={(e) => setNewDisplayLocation((e.target as HTMLInputElement).value)}
           label="Display location"
           value={newDisplayLocation}
         />
 
         {newDisplayName.length > 0 && (
           <p>
-            Your name will display as <strong>{newDisplayName} {newDisplayLocation.length > 0 && <>({newDisplayLocation})</>}</strong>
+            Your name will display as{" "}
+            <strong>
+              {newDisplayName} {newDisplayLocation.length > 0 && <>({newDisplayLocation})</>}
+            </strong>
           </p>
         )}
 
         <div
           className={cx("ControlledInput", {
-            "ControlledInput--warning": !newTimezone
+            "ControlledInput--warning": !newTimezone,
           })}
         >
-          <label>
-            My timezone is
-          </label>
+          <label>My timezone is</label>
           <select
             onChange={(e) => {
-              parseTimezone(e.currentTarget.value)
-              setNewTimezone(e.currentTarget.value)
+              parseTimezone(e.currentTarget.value);
+              setNewTimezone(e.currentTarget.value);
             }}
             value={newTimezone}
           >
             {options.map((option) => (
-              <option key={option.value} value={option.value}>{option.label}</option>
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
             ))}
           </select>
         </div>
@@ -139,18 +143,34 @@ export const UserSettings = () => {
         />
       </div>
 
-      {isSuccess && allGroups.length > 0 && ( // TODO improve this area lol
-        <div>
-          <h3>Upcoming groups</h3>
-          <GroupArchive groups={allGroups.filter((g) => {
-            return dayjs(g.start.toDate()).isAfter(dayjs())
-          })} />
-          <h3>Past groups</h3>
-          <GroupArchive groups={allGroups.filter((g) => {
-            return dayjs(g.end.toDate()).isBefore(dayjs())
-          })} />
-        </div>
-      )}
+      {isSuccess &&
+        allGroups.length > 0 && ( // TODO improve this area lol
+          <div>
+            <h3>Upcoming groups</h3>
+            <GroupArchive
+              groups={allGroups.filter((g) => {
+                return dayjs(g.start.toDate()).isAfter(dayjs());
+              })}
+            />
+            <h3>Past groups</h3>
+            <GroupArchive
+              groups={allGroups.filter((g) => {
+                return dayjs(g.end.toDate()).isBefore(dayjs());
+              })}
+            />
+          </div>
+        )}
+      <button
+        onClick={() => {
+          // Send a log before throwing the error
+          Sentry.logger.info("User triggered test error", {
+            action: "test_error_button_click",
+          });
+          throw new Error("This is your first error!");
+        }}
+      >
+        Break the world
+      </button>
     </div>
-  )
-}
+  );
+};

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -1,107 +1,85 @@
-import { ErrorInfo } from '../types/error'
+import * as Sentry from "@sentry/react";
+import { ErrorInfo } from "../types/error";
 
 class GlobalErrorHandler {
-  private static instance: GlobalErrorHandler
-  private errorQueue: ErrorInfo[] = []
-  private isInitialized = false
+  private static instance: GlobalErrorHandler;
+  private errorQueue: ErrorInfo[] = [];
+  private isInitialized = false;
+  private showToast: ((message?: string) => void) | null = null;
 
   private constructor() {}
 
   static getInstance(): GlobalErrorHandler {
     if (!GlobalErrorHandler.instance) {
-      GlobalErrorHandler.instance = new GlobalErrorHandler()
+      GlobalErrorHandler.instance = new GlobalErrorHandler();
     }
-    return GlobalErrorHandler.instance
+    return GlobalErrorHandler.instance;
   }
 
-  initialize(showToast: (message: string) => void) {
-    if (this.isInitialized) return
+  initialize(showToast: (message?: string) => void) {
+    this.showToast = showToast;
+    if (this.isInitialized) return;
 
-    // Handle unhandled JavaScript errors
-    window.addEventListener('error', (event) => {
-      const errorInfo: ErrorInfo = {
+    window.addEventListener("error", (event) => {
+      this.handleError({
         message: event.message,
         stack: event.error?.stack,
-        source: 'javascript',
+        source: "javascript",
         timestamp: new Date(),
         userAgent: navigator.userAgent,
-        url: window.location.href
-      }
+        url: window.location.href,
+      });
+    });
 
-      this.handleError(errorInfo, showToast)
-    })
-
-    // Handle unhandled promise rejections
-    window.addEventListener('unhandledrejection', (event) => {
-      const errorInfo: ErrorInfo = {
+    window.addEventListener("unhandledrejection", (event) => {
+      this.handleError({
         message: event.reason?.message || String(event.reason),
         stack: event.reason?.stack,
-        source: 'promise',
+        source: "promise",
         timestamp: new Date(),
         userAgent: navigator.userAgent,
-        url: window.location.href
-      }
+        url: window.location.href,
+      });
+    });
 
-      this.handleError(errorInfo, showToast)
-    })
-
-    this.isInitialized = true
+    this.isInitialized = true;
   }
 
-  // Public method for manually reporting errors
-  reportError(error: Error, source: string = 'manual', showToast: (message: string) => void) {
-    const errorInfo: ErrorInfo = {
+  reportError(error: Error, source: string = "manual") {
+    this.handleError({
       message: error.message,
       stack: error.stack,
       source,
       timestamp: new Date(),
       userAgent: navigator.userAgent,
-      url: window.location.href
-    }
-
-    this.handleError(errorInfo, showToast)
+      url: window.location.href,
+    });
   }
 
-  private handleError(errorInfo: ErrorInfo, showToast: (message: string) => void) {
-    // Log to console for development
-    console.error('Global Error Handler:', {
-      ...errorInfo,
-      timestamp: errorInfo.timestamp.toISOString()
-    })
+  private handleError(errorInfo: ErrorInfo) {
+    console.error("Error:", errorInfo);
 
-    // Add to queue for potential batch reporting
-    this.errorQueue.push(errorInfo)
+    Sentry.captureException(new Error(errorInfo.message), {
+      extra: { source: errorInfo.source, url: errorInfo.url },
+    });
 
-    // Show user-friendly notification
-    const userMessage = this.getUserFriendlyMessage(errorInfo)
-    showToast(userMessage)
-
-    // Optional: Send to external service
-    // this.sendToLoggingService(errorInfo)
+    this.errorQueue.push(errorInfo);
+    this.showToast?.(this.getUserFriendlyMessage(errorInfo));
   }
 
   private getUserFriendlyMessage(errorInfo: ErrorInfo): string {
-    // Customize based on error type or source
-    if (errorInfo.source === 'promise' && errorInfo.message.includes('fetch')) {
-      return 'Connection issue detected. Please check your internet and try again.'
-    }
-
-    if (errorInfo.message.includes('permission')) {
-      return 'Permission error. Please refresh the page or contact support.'
-    }
-
-    return 'Something unexpected happened. The error has been logged and we\'re looking into it.'
+    // Extensibility point: return specific messages for anticipated error types
+    if (errorInfo.source === "network") return "Connection issue. Please check your internet.";
+    return "An error has occurred";
   }
 
-  // Get recent errors for debugging
   getRecentErrors(count: number = 10): ErrorInfo[] {
-    return this.errorQueue.slice(-count)
+    return this.errorQueue.slice(-count);
   }
 
-  // Clear error queue
   clearErrors(): void {
-    this.errorQueue = []
+    this.errorQueue = [];
   }
 }
 
-export default GlobalErrorHandler
+export default GlobalErrorHandler;


### PR DESCRIPTION
- ToastProvider (ToastContext.tsx): wraps the app and renders the Snackbar; provides showToast via context so any component can call it without prop-drilling — import useToastContext from hooks/useToastContext
- Snackbar (ToastContainer.tsx + Snackbar.scss): position:fixed top-of- viewport banner, z-index 1100, slides in from top, 0.75rem text, one toast at a time, auto-dismisses in 4s; close button for early dismiss
- GlobalErrorHandler: stores showToast internally after initialize() so reportError(error, source?) no longer needs it as a param; calls Sentry.captureException on every error; getUserFriendlyMessage is the extensibility point for anticipated error messages — return a specific string there to override the default "An error has occurred"
- ErrorBoundary: no longer needs showToast prop; now wired into App around <Routes> so React render errors are caught and shown
- useToast: default message "An error has occurred"; one toast at a time (newer replaces older)
- Fix pre-existing lint issues in me/index.tsx (unused vars, any types) and remove the now-unnecessary @ts-ignore in App.tsx