### PR TITLE
Log summary overhaul

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -437,6 +437,14 @@ html {
       align-items: center;
       width: fit-content;
     }
+
+    &__title {
+      font-weight: 700;
+      max-width: 100%;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 
   &__body {

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,0 +1,40 @@
+import cx from "classnames";
+
+export interface TabItem {
+  id: string;
+  label: string;
+}
+
+interface TabsProps {
+  tabs: TabItem[];
+  activeId: string;
+  onChange: (id: string) => void;
+  className?: string;
+  ariaLabel?: string;
+}
+
+// Filing-folder style tabs that peek up out of the top border of the box below.
+// Pair with a `.Window` sibling directly beneath it.
+const Tabs = ({ tabs, activeId, onChange, className, ariaLabel }: TabsProps) => {
+  return (
+    <div className={cx("Tabs", className)} role="tablist" aria-label={ariaLabel}>
+      {tabs.map((tab) => {
+        const isActive = tab.id === activeId;
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            className={cx("Tabs__tab", { "Tabs__tab--active": isActive })}
+            onClick={() => onChange(tab.id)}
+          >
+            {tab.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default Tabs;

--- a/src/components/__tests__/Tabs.test.tsx
+++ b/src/components/__tests__/Tabs.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vite-plus/test";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import Tabs from "@/components/Tabs";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const TABS = [
+  { id: "mine", label: "My spending" },
+  { id: "group", label: "Group spending" },
+];
+
+describe("Tabs", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders a tab per item and marks the active one", () => {
+    act(() => root.render(<Tabs tabs={TABS} activeId="group" onChange={() => {}} />));
+
+    const tabs = container.querySelectorAll<HTMLButtonElement>("[role='tab']");
+    expect(tabs).toHaveLength(2);
+
+    const active = container.querySelector(".Tabs__tab--active");
+    expect(active?.textContent).toBe("Group spending");
+    expect(active?.getAttribute("aria-selected")).toBe("true");
+
+    const inactive = Array.from(tabs).find((t) => t.textContent === "My spending")!;
+    expect(inactive.getAttribute("aria-selected")).toBe("false");
+    expect(inactive.className).not.toContain("Tabs__tab--active");
+  });
+
+  it("calls onChange with the clicked tab's id", () => {
+    const onChange = vi.fn();
+    act(() => root.render(<Tabs tabs={TABS} activeId="mine" onChange={onChange} />));
+
+    const groupTab = Array.from(container.querySelectorAll<HTMLButtonElement>("[role='tab']")).find(
+      (t) => t.textContent === "Group spending",
+    )!;
+    act(() => groupTab.click());
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("group");
+  });
+});

--- a/src/features/moneylog/components/Group.tsx
+++ b/src/features/moneylog/components/Group.tsx
@@ -262,6 +262,11 @@ export const Group = ({
           </div>
 
           <div className="Group__header__center">
+            {displaySummary && (
+              <div className="Group__header__item Group__header__title">
+                Insights for {group.title}
+              </div>
+            )}
             {!isPostingClosed &&
               !displayAll &&
               isActiveLogMyLog &&

--- a/src/features/moneylog/components/LogsSummary/AchievementsBanner.tsx
+++ b/src/features/moneylog/components/LogsSummary/AchievementsBanner.tsx
@@ -1,4 +1,5 @@
 import { Achievement, ACHIEVEMENT_META } from "@/hooks/useAchievements";
+import Icon from "@/components/Icon";
 
 const AchievementsBanner = ({ achievements }: { achievements: Achievement[] }) => {
   if (achievements.length === 0) return null;
@@ -11,8 +12,8 @@ const AchievementsBanner = ({ achievements }: { achievements: Achievement[] }) =
           const meta = ACHIEVEMENT_META[achievement.type];
           return (
             <div key={achievement.id} className="AchievementsBanner__card">
-              <span className="AchievementsBanner__card__emoji" role="img" aria-label={meta.title}>
-                {meta.emoji}
+              <span className="AchievementsBanner__card__icon" aria-hidden="true">
+                <Icon type={meta.icon} />
               </span>
               <div className="AchievementsBanner__card__text">
                 <strong>{meta.title}</strong>

--- a/src/features/moneylog/components/LogsSummary/HotPosts.tsx
+++ b/src/features/moneylog/components/LogsSummary/HotPosts.tsx
@@ -87,7 +87,7 @@ const HotPosts = ({
 
   return (
     <div className="HotPostsWindow Window" ref={hotPostsRef}>
-      <h3>🔥 hot posts</h3>
+      <h3>hot posts</h3>
       <p className="HotPosts__description">
         These posts got a lot of attention! ({hotPosts.length} post
         {hotPosts.length !== 1 ? "s" : ""} shown)

--- a/src/features/moneylog/components/LogsSummary/LogsSummary.tsx
+++ b/src/features/moneylog/components/LogsSummary/LogsSummary.tsx
@@ -21,6 +21,7 @@ import LogPostComments from "@/features/moneylog/components/LogPosts/LogPostComm
 import "./styles.scss";
 import CustomDropdown, { DropdownOption } from "@/components/CustomDropdown";
 import Button from "@/components/Button";
+import Tabs, { TabItem } from "@/components/Tabs";
 
 interface LogsSummaryProps {
   group: Group;
@@ -225,8 +226,6 @@ const LogsSummary = ({ group, groupMembers, logPosts }: LogsSummaryProps) => {
   return (
     <>
       <div className={cx("LogsSummary", { "disable-scroll": !!selectedPost })}>
-        <h2>Insights for {group.title}</h2>
-
         <AchievementsBanner achievements={newAchievements} />
 
         {isAdmin && (
@@ -245,58 +244,53 @@ const LogsSummary = ({ group, groupMembers, logPosts }: LogsSummaryProps) => {
           </div>
         )}
 
-        <div className="Window LogsSummary__spending">
-          <div className="Segmented Segmented--tabs" role="tablist" aria-label="Spending view">
-            <Button
-              text="My spending"
-              size="sm"
-              buttonStyle="primary-border"
-              isSelected={spendingTab === "mine"}
-              onClick={() => setSpendingTab("mine")}
-            />
-            <Button
-              text="Group spending"
-              size="sm"
-              buttonStyle="primary-border"
-              isSelected={spendingTab === "group"}
-              onClick={() => setSpendingTab("group")}
-            />
-            {isAdmin && otherUser && (
-              <Button
-                text={otherUser.displayName}
-                size="sm"
-                buttonStyle="primary-border"
-                isSelected={spendingTab === "other"}
-                onClick={() => setSpendingTab("other")}
+        <div className="LogsSummary__spending">
+          <Tabs
+            ariaLabel="Spending view"
+            activeId={spendingTab}
+            onChange={(id) => setSpendingTab(id as "mine" | "group" | "other")}
+            tabs={
+              [
+                { id: "mine", label: "My spending" },
+                { id: "group", label: "Group spending" },
+                ...(isAdmin && otherUser ? [{ id: "other", label: otherUser.displayName }] : []),
+              ] as TabItem[]
+            }
+          />
+
+          <div className="Window LogsSummary__spending__body">
+            {spendingTab === "mine" && loggedInUser && (
+              <SpendingPanel
+                key="mine"
+                scope="mine"
+                user={memberIdToMembers.get(loggedInUser.id) ?? {}}
+                logPosts={myLogs}
+                group={group}
+                groupAnalytics={groupAnalytics}
+              />
+            )}
+
+            {spendingTab === "group" && (
+              <SpendingPanel
+                key="group"
+                scope="group"
+                user={{}}
+                logPosts={logPosts}
+                group={group}
+              />
+            )}
+
+            {spendingTab === "other" && otherLogs && otherUser && (
+              <SpendingPanel
+                key={`other-${otherUser.id}`}
+                scope="other"
+                user={otherUser}
+                logPosts={otherLogs}
+                group={group}
+                groupAnalytics={groupAnalytics}
               />
             )}
           </div>
-
-          {spendingTab === "mine" && loggedInUser && (
-            <SpendingPanel
-              key="mine"
-              scope="mine"
-              user={memberIdToMembers.get(loggedInUser.id) ?? {}}
-              logPosts={myLogs}
-              group={group}
-              groupAnalytics={groupAnalytics}
-            />
-          )}
-
-          {spendingTab === "group" && (
-            <SpendingPanel key="group" scope="group" user={{}} logPosts={logPosts} group={group} />
-          )}
-
-          {spendingTab === "other" && otherLogs && otherUser && (
-            <SpendingPanel
-              key={`other-${otherUser.id}`}
-              scope="other"
-              user={otherUser}
-              logPosts={otherLogs}
-              group={group}
-              groupAnalytics={groupAnalytics}
-            />
-          )}
         </div>
 
         <HotPosts

--- a/src/features/moneylog/components/LogsSummary/LogsSummary.tsx
+++ b/src/features/moneylog/components/LogsSummary/LogsSummary.tsx
@@ -13,7 +13,7 @@ import { useGroupAnalytics } from "./hooks/useGroupAnalytics";
 import { Achievement, awardGroupAchievements } from "@/hooks/useAchievements";
 
 import Loader from "@/features/layout/components/Loader";
-import SpendingInsights from "./SpendingInsights";
+import SpendingPanel from "./SpendingPanel";
 import HotPosts from "./HotPosts";
 import AchievementsBanner from "./AchievementsBanner";
 import LogPostComments from "@/features/moneylog/components/LogPosts/LogPostComments";
@@ -53,6 +53,9 @@ const LogsSummary = ({ group, groupMembers, logPosts }: LogsSummaryProps) => {
   }, [groupMembers]);
 
   const [otherLogs, setOtherLogs] = useState<LogPost[] | null>(null);
+  const [spendingTab, setSpendingTab] = useState<"mine" | "group" | "other">("mine");
+
+  const isAdmin = loggedInUser?.email === "cui.naomi@gmail.com";
 
   const processAnalytics = useMemo(() => httpsCallable(functions, "processGroupAnalytics"), []);
 
@@ -62,7 +65,10 @@ const LogsSummary = ({ group, groupMembers, logPosts }: LogsSummaryProps) => {
 
   const handleSelectTestOtherLogs = (userId: string) => {
     setOtherLogs(logPosts.filter((logPost) => logPost.author.id === userId));
+    setSpendingTab("other");
   };
+
+  const otherUser = otherLogs?.[0] ? memberIdToMembers.get(otherLogs[0].author.id) : undefined;
 
   const [selectedPost, setSelectedPost] = useState<LogPost | null>(null);
   useDisableScroll(!!selectedPost);
@@ -175,7 +181,7 @@ const LogsSummary = ({ group, groupMembers, logPosts }: LogsSummaryProps) => {
       <div className="LogsSummary">
         <h2>Preparing insights for {group.title}</h2>
         <div className="Window">
-          <h3>📊 Processing analytics...</h3>
+          <h3>Processing analytics...</h3>
           <div style={{ padding: "2rem", textAlign: "center" }}>
             <p style={{ marginBottom: "1rem", fontSize: "1.1em" }}>{processingState.step}</p>
             <Loader progress={processingState.percentage} />
@@ -194,21 +200,21 @@ const LogsSummary = ({ group, groupMembers, logPosts }: LogsSummaryProps) => {
       <div className="LogsSummary">
         <h2>Insights for {group.title}</h2>
         <div className="Window">
-          <h3>⚠️ Processing Error</h3>
+          <h3>Processing error</h3>
           <p>Failed to process analytics: {analyticsError}</p>
           <p>Falling back to real-time analysis...</p>
         </div>
 
-        {/* Fallback to original component structure */}
+        {/* Fallback to real-time spending panel */}
         {loggedInUser && (
           <div className="Window">
-            <h3>💰 {loggedInUser?.displayName}'s spending</h3>
-            <SpendingInsights user={loggedInUser} logPosts={myLogs} group={group}>
-              <SpendingInsights.TotalText>
-                You spent a <strong>total of</strong>
-              </SpendingInsights.TotalText>
-              {/* Add other components as needed */}
-            </SpendingInsights>
+            <SpendingPanel
+              scope="mine"
+              user={memberIdToMembers.get(loggedInUser.id) ?? {}}
+              logPosts={myLogs}
+              group={group}
+              groupAnalytics={groupAnalytics}
+            />
           </div>
         )}
       </div>
@@ -223,13 +229,7 @@ const LogsSummary = ({ group, groupMembers, logPosts }: LogsSummaryProps) => {
 
         <AchievementsBanner achievements={newAchievements} />
 
-        {/*{hasAnalytics && (
-          <div className="LogsSummary__badge">
-            📈 Using cached analytics from {new Date(group.analytics.processedAt.seconds * 1000).toLocaleDateString()}
-          </div>
-        )}*/}
-
-        {loggedInUser?.email === "cui.naomi@gmail.com" && (
+        {isAdmin && (
           <div>
             <CustomDropdown
               options={group.members.map((m) => ({
@@ -245,96 +245,58 @@ const LogsSummary = ({ group, groupMembers, logPosts }: LogsSummaryProps) => {
           </div>
         )}
 
-        {loggedInUser?.email === "cui.naomi@gmail.com" && otherLogs && otherLogs?.length > 0 && (
-          <div className="Window">
-            <h3>💰 {memberIdToMembers.get(otherLogs?.[0].author.id)?.displayName}'s spending</h3>
-
-            <SpendingInsights
-              user={memberIdToMembers.get(otherLogs?.[0].author.id) ?? {}}
-              logPosts={otherLogs}
-              group={group}
-            >
-              <SpendingInsights.TotalText>
-                This user spent a <strong>total of</strong>
-              </SpendingInsights.TotalText>
-
-              <SpendingInsights.WeekText>
-                This user <strong>spent the most</strong> during the <strong>week(s) of</strong>
-              </SpendingInsights.WeekText>
-
-              <SpendingInsights.DayText showPosts={true}>
-                This user <strong>day you spent the most</strong> was
-              </SpendingInsights.DayText>
-
-              <SpendingInsights.AveragesText>
-                Here are this user's average <strong>spending patterns</strong>:
-              </SpendingInsights.AveragesText>
-
-              <SpendingInsights.WeekendWeekdayText>{""}</SpendingInsights.WeekendWeekdayText>
-
-              <SpendingInsights.NoSpendDaysText>
-                This user had <strong>no spending</strong> on
-              </SpendingInsights.NoSpendDaysText>
-
-              <SpendingInsights.LowSpenderAlert groupAnalytics={groupAnalytics}>
-                💡 <strong>Good news!</strong>
-              </SpendingInsights.LowSpenderAlert>
-            </SpendingInsights>
+        <div className="Window LogsSummary__spending">
+          <div className="Segmented Segmented--tabs" role="tablist" aria-label="Spending view">
+            <Button
+              text="My spending"
+              size="sm"
+              buttonStyle="primary-border"
+              isSelected={spendingTab === "mine"}
+              onClick={() => setSpendingTab("mine")}
+            />
+            <Button
+              text="Group spending"
+              size="sm"
+              buttonStyle="primary-border"
+              isSelected={spendingTab === "group"}
+              onClick={() => setSpendingTab("group")}
+            />
+            {isAdmin && otherUser && (
+              <Button
+                text={otherUser.displayName}
+                size="sm"
+                buttonStyle="primary-border"
+                isSelected={spendingTab === "other"}
+                onClick={() => setSpendingTab("other")}
+              />
+            )}
           </div>
-        )}
 
-        {loggedInUser && (
-          <div className="Window">
-            <h3>💰 {loggedInUser?.displayName}'s spending</h3>
-            <SpendingInsights
+          {spendingTab === "mine" && loggedInUser && (
+            <SpendingPanel
+              key="mine"
+              scope="mine"
               user={memberIdToMembers.get(loggedInUser.id) ?? {}}
               logPosts={myLogs}
               group={group}
-            >
-              <SpendingInsights.TotalText>
-                You spent a <strong>total of</strong>
-              </SpendingInsights.TotalText>
+              groupAnalytics={groupAnalytics}
+            />
+          )}
 
-              <SpendingInsights.WeekText>
-                You <strong>spent the most</strong> during the <strong>week(s) of</strong>
-              </SpendingInsights.WeekText>
+          {spendingTab === "group" && (
+            <SpendingPanel key="group" scope="group" user={{}} logPosts={logPosts} group={group} />
+          )}
 
-              <SpendingInsights.DayText showPosts={true}>
-                The <strong>day you spent the most</strong> was
-              </SpendingInsights.DayText>
-
-              <SpendingInsights.AveragesText>
-                Here are your average <strong>spending patterns</strong>:
-              </SpendingInsights.AveragesText>
-
-              <SpendingInsights.WeekendWeekdayText>{""}</SpendingInsights.WeekendWeekdayText>
-
-              <SpendingInsights.NoSpendDaysText>
-                You logged <strong>no spending</strong> on
-              </SpendingInsights.NoSpendDaysText>
-
-              <SpendingInsights.LowSpenderAlert groupAnalytics={groupAnalytics}>
-                💡 <strong>Good news!</strong>
-              </SpendingInsights.LowSpenderAlert>
-            </SpendingInsights>
-          </div>
-        )}
-
-        <div className="Window">
-          <h3>💸 group spending</h3>
-          <SpendingInsights user={{}} logPosts={logPosts} group={group}>
-            <SpendingInsights.TotalText>
-              The group spent a <strong>total of</strong>
-            </SpendingInsights.TotalText>
-
-            <SpendingInsights.WeekText>
-              The group <strong>spent the most</strong> during the <strong>weeks of</strong>
-            </SpendingInsights.WeekText>
-
-            <SpendingInsights.DayText showPosts={true} showAuthors={true} showMultipleDays={true}>
-              The <strong>days the group spent the most</strong> were
-            </SpendingInsights.DayText>
-          </SpendingInsights>
+          {spendingTab === "other" && otherLogs && otherUser && (
+            <SpendingPanel
+              key={`other-${otherUser.id}`}
+              scope="other"
+              user={otherUser}
+              logPosts={otherLogs}
+              group={group}
+              groupAnalytics={groupAnalytics}
+            />
+          )}
         </div>
 
         <HotPosts

--- a/src/features/moneylog/components/LogsSummary/PostPreview.tsx
+++ b/src/features/moneylog/components/LogsSummary/PostPreview.tsx
@@ -1,0 +1,35 @@
+import MDEditor from "@uiw/react-md-editor";
+import { LogPost } from "@/types/user";
+import Icon from "@/components/Icon";
+
+interface PostPreviewProps {
+  post: LogPost;
+  showAuthor?: boolean;
+}
+
+// Small read-only card for a single post — used in the expensive-day preview and
+// when a chart bar is clicked.
+const PostPreview = ({ post, showAuthor = false }: PostPreviewProps) => {
+  return (
+    <div className="PostPreview" data-color-mode="light">
+      <div className="PostPreview__header">
+        <strong>
+          {post.amount.toLocaleString("en-US", {
+            minimumFractionDigits: 0,
+            maximumFractionDigits: 2,
+          })}{" "}
+          {post.currency}
+        </strong>
+      </div>
+      <MDEditor.Markdown source={post.content} />
+      {showAuthor && post.authorName && (
+        <div className="PostPreview__footer">
+          <Icon type={"user"} />
+          {post.authorName}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PostPreview;

--- a/src/features/moneylog/components/LogsSummary/SpendingChart.tsx
+++ b/src/features/moneylog/components/LogsSummary/SpendingChart.tsx
@@ -1,0 +1,216 @@
+import { useMemo, useRef, useState } from "react";
+import cx from "classnames";
+import { Currency } from "@/types/user";
+import { SpendingPoint } from "./spendingSeries";
+
+type ChartMode = "bars" | "cumulative";
+
+interface SpendingChartProps {
+  series: SpendingPoint[];
+  mode: ChartMode;
+  currency: Currency;
+  onSelectPoint?: (point: SpendingPoint) => void;
+  selectedKey?: string | null;
+}
+
+// Fixed viewBox; CSS scales the SVG responsively (uniform, so strokes stay crisp).
+const VW = 640;
+const VH = 240;
+const PAD = { top: 16, right: 10, bottom: 28, left: 10 };
+const PLOT_W = VW - PAD.left - PAD.right;
+const PLOT_H = VH - PAD.top - PAD.bottom;
+const BASELINE = PAD.top + PLOT_H;
+
+const fmt = (value: number, currency: Currency) =>
+  `${value.toLocaleString("en-US", { maximumFractionDigits: 2 })} ${currency}`;
+
+// A bar with only its top two corners rounded, anchored to the baseline.
+const topRoundedBar = (x: number, y: number, w: number, h: number, r: number) => {
+  const radius = Math.max(0, Math.min(r, w / 2, h));
+  if (radius === 0) return `M${x},${y} h${w} v${h} h${-w} Z`;
+  return [
+    `M${x},${y + radius}`,
+    `a${radius},${radius} 0 0 1 ${radius},${-radius}`,
+    `h${w - 2 * radius}`,
+    `a${radius},${radius} 0 0 1 ${radius},${radius}`,
+    `v${h - radius}`,
+    `h${-w}`,
+    `Z`,
+  ].join(" ");
+};
+
+const SpendingChart = ({
+  series,
+  mode,
+  currency,
+  onSelectPoint,
+  selectedKey,
+}: SpendingChartProps) => {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [hover, setHover] = useState<number | null>(null);
+  const [tooltip, setTooltip] = useState<{ x: number; y: number } | null>(null);
+
+  const n = series.length;
+  const band = n > 0 ? PLOT_W / n : PLOT_W;
+  const gap = n > 40 ? 1 : 2;
+  const barWidth = Math.max(1, band - gap);
+
+  const yMax = useMemo(() => {
+    const values = series.map((p) => (mode === "cumulative" ? p.cumulative : p.amount));
+    return Math.max(1, ...values);
+  }, [series, mode]);
+
+  const xCenter = (i: number) => PAD.left + band * i + band / 2;
+  const yOf = (v: number) => PAD.top + PLOT_H * (1 - v / yMax);
+
+  const linePath = useMemo(() => {
+    if (mode !== "cumulative" || n === 0) return "";
+    return series
+      .map((p, i) => `${i === 0 ? "M" : "L"}${xCenter(i)},${yOf(p.cumulative)}`)
+      .join(" ");
+  }, [series, mode, n, yMax]);
+
+  const areaPath = useMemo(() => {
+    if (mode !== "cumulative" || n === 0) return "";
+    const top = series
+      .map((p, i) => `${i === 0 ? "M" : "L"}${xCenter(i)},${yOf(p.cumulative)}`)
+      .join(" ");
+    return `${top} L${xCenter(n - 1)},${BASELINE} L${xCenter(0)},${BASELINE} Z`;
+  }, [series, mode, n, yMax]);
+
+  const updateTooltip = (index: number, evt: React.MouseEvent) => {
+    const rect = wrapperRef.current?.getBoundingClientRect();
+    setHover(index);
+    if (rect) setTooltip({ x: evt.clientX - rect.left, y: evt.clientY - rect.top });
+  };
+
+  // Axis labels: first, middle, last bucket.
+  const labelIdx = n <= 1 ? [0] : [0, Math.floor((n - 1) / 2), n - 1];
+
+  const hovered = hover != null ? series[hover] : null;
+  const summary =
+    mode === "cumulative"
+      ? `Cumulative ${currency} spending over time. Ends at ${fmt(series[n - 1]?.cumulative ?? 0, currency)}.`
+      : `${currency} spending per period. Highest period ${fmt(yMax, currency)}.`;
+
+  return (
+    <div className="SpendingChart" ref={wrapperRef}>
+      <svg
+        className="SpendingChart__svg"
+        viewBox={`0 0 ${VW} ${VH}`}
+        preserveAspectRatio="xMidYMid meet"
+        role="img"
+        aria-label={summary}
+      >
+        {/* recessive top gridline at the max value */}
+        <line
+          className="SpendingChart__grid"
+          x1={PAD.left}
+          y1={yOf(yMax)}
+          x2={VW - PAD.right}
+          y2={yOf(yMax)}
+        />
+        <text className="SpendingChart__ytick" x={PAD.left} y={yOf(yMax) - 4}>
+          {fmt(yMax, currency)}
+        </text>
+
+        {mode === "cumulative" && (
+          <>
+            <path className="SpendingChart__area" d={areaPath} />
+            <path className="SpendingChart__line" d={linePath} />
+          </>
+        )}
+
+        {mode === "bars" &&
+          series.map((p, i) => {
+            const h = BASELINE - yOf(p.amount);
+            const isSelected = selectedKey != null && p.key === selectedKey;
+            return (
+              <path
+                key={p.key}
+                className={cx("SpendingChart__bar", {
+                  "SpendingChart__bar--hover": hover === i,
+                  "SpendingChart__bar--dim": selectedKey != null && !isSelected,
+                })}
+                d={topRoundedBar(PAD.left + band * i + gap / 2, yOf(p.amount), barWidth, h, 4)}
+              />
+            );
+          })}
+
+        {/* hovered/selected marker for the cumulative line */}
+        {mode === "cumulative" && hovered && hover != null && (
+          <circle
+            className="SpendingChart__dot"
+            cx={xCenter(hover)}
+            cy={yOf(hovered.cumulative)}
+            r={4}
+          />
+        )}
+
+        {/* baseline */}
+        <line
+          className="SpendingChart__axis"
+          x1={PAD.left}
+          y1={BASELINE}
+          x2={VW - PAD.right}
+          y2={BASELINE}
+        />
+
+        {/* x labels */}
+        {labelIdx.map((i) => (
+          <text
+            key={`xl-${i}`}
+            className="SpendingChart__xtick"
+            x={xCenter(i)}
+            y={BASELINE + 16}
+            textAnchor={i === 0 ? "start" : i === n - 1 ? "end" : "middle"}
+          >
+            {series[i]?.date.format("D MMM")}
+          </text>
+        ))}
+
+        {/* full-height hit targets, one per bucket (bigger than the mark) */}
+        {series.map((p, i) => (
+          <rect
+            key={`hit-${p.key}`}
+            className="SpendingChart__hit"
+            x={PAD.left + band * i}
+            y={PAD.top}
+            width={band}
+            height={PLOT_H}
+            tabIndex={0}
+            role="button"
+            aria-label={`${p.label}: ${fmt(mode === "cumulative" ? p.cumulative : p.amount, currency)}`}
+            onMouseEnter={(e) => updateTooltip(i, e)}
+            onMouseMove={(e) => updateTooltip(i, e)}
+            onMouseLeave={() => {
+              setHover(null);
+              setTooltip(null);
+            }}
+            onFocus={() => setHover(i)}
+            onBlur={() => setHover(null)}
+            onClick={() => onSelectPoint?.(p)}
+          />
+        ))}
+      </svg>
+
+      {hovered && tooltip && (
+        <div
+          className="SpendingChart__tooltip"
+          style={{ left: tooltip.x, top: tooltip.y }}
+          role="status"
+        >
+          <strong>{hovered.label}</strong>
+          <span>{fmt(mode === "cumulative" ? hovered.cumulative : hovered.amount, currency)}</span>
+          {mode === "bars" && hovered.posts.length > 0 && (
+            <span className="SpendingChart__tooltip__meta">
+              {hovered.posts.length} post{hovered.posts.length === 1 ? "" : "s"}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SpendingChart;

--- a/src/features/moneylog/components/LogsSummary/SpendingInsights.tsx
+++ b/src/features/moneylog/components/LogsSummary/SpendingInsights.tsx
@@ -19,6 +19,8 @@ interface SpendingData {
   noSpendDays: number;
   totalDaysInPeriod: number;
   group: Group;
+  // When set, currency-specific cards show only this currency (the toggled one).
+  activeCurrency: Currency | null;
 }
 
 // New interface for group-wide analytics (passed from parent)
@@ -41,10 +43,11 @@ interface SpendingInsightsProps {
   logPosts: Array<LogPost>;
   group: Group;
   groupAnalytics?: GroupAnalytics; // Optional for now, for low-spender detection
+  currency?: Currency | null; // when set, cards show only this currency
   children: ReactNode;
 }
 
-const SpendingInsights = ({ user, logPosts, group, children }: SpendingInsightsProps) => {
+const SpendingInsights = ({ user, logPosts, group, currency, children }: SpendingInsightsProps) => {
   const spendingData = useMemo(() => {
     const hasCachedAnalytics = group.analytics?.isCalculated;
     const postsMetadata = group.analytics?.posts;
@@ -260,8 +263,21 @@ const SpendingInsights = ({ user, logPosts, group, children }: SpendingInsightsP
     };
   }, [logPosts, group]);
 
-  return <SpendingContext.Provider value={spendingData}>{children}</SpendingContext.Provider>;
+  // Merge the toggled currency in outside the heavy memo so switching currency
+  // doesn't recompute the aggregation.
+  const contextValue = useMemo(
+    () => ({ ...spendingData, activeCurrency: currency ?? null }),
+    [spendingData, currency],
+  );
+
+  return <SpendingContext.Provider value={contextValue}>{children}</SpendingContext.Provider>;
 };
+
+// Keeps only entries for the toggled currency; shows all when none is set.
+const currencyFilter =
+  (activeCurrency: Currency | null) =>
+  <T,>([currency]: [Currency, T]) =>
+    !activeCurrency || currency === activeCurrency;
 
 // Existing components (unchanged)
 const TotalText = ({ children }: { children: ReactNode }) => {
@@ -474,17 +490,20 @@ const DayText = ({
 
 // New components for the additional analytics
 const AveragesText = ({ children }: { children: ReactNode }) => {
-  const { weeklyAverages, dailyAverages } = useSpendingData();
+  const { weeklyAverages, dailyAverages, activeCurrency } = useSpendingData();
+
+  const weekly = [...weeklyAverages.entries()].filter(currencyFilter(activeCurrency));
+  const daily = [...dailyAverages.entries()].filter(currencyFilter(activeCurrency));
 
   return (
     <div className="LogsSummary__bubble">
       <div>{children}</div>
 
-      {weeklyAverages.size > 0 && (
+      {weekly.length > 0 && (
         <div>
           <strong>Weekly averages:</strong>{" "}
           <span className="LogsSummary__highlight">
-            {[...weeklyAverages.entries()]
+            {weekly
               .map(
                 ([currency, avg]) =>
                   `${avg.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${currency}`,
@@ -494,11 +513,11 @@ const AveragesText = ({ children }: { children: ReactNode }) => {
         </div>
       )}
 
-      {dailyAverages.size > 0 && (
+      {daily.length > 0 && (
         <div>
           <strong>Daily averages:</strong>{" "}
           <span className="LogsSummary__highlight">
-            {[...dailyAverages.entries()]
+            {daily
               .map(
                 ([currency, avg]) =>
                   `${avg.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${currency}`,
@@ -512,56 +531,39 @@ const AveragesText = ({ children }: { children: ReactNode }) => {
 };
 
 const WeekendWeekdayText = ({ children }: { children: ReactNode }) => {
-  const { weekendVsWeekdayDiff } = useSpendingData();
+  const { weekendVsWeekdayDiff, activeCurrency } = useSpendingData();
 
-  if (weekendVsWeekdayDiff.size === 0) return;
+  const entries = [...weekendVsWeekdayDiff.entries()].filter(currencyFilter(activeCurrency));
+  if (entries.length === 0) return null;
+
+  const num = (v: number) =>
+    v.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 2 });
 
   return (
     <div className="LogsSummary__bubble">
       <div>{children}</div>
 
-      {[...weekendVsWeekdayDiff.entries()].map(([currency, data]) => (
+      {entries.map(([currency, data]) => (
         <div key={`weekend-weekday-${currency}`}>
-          <strong>{currency}:</strong> On weekends you spent an average of{" "}
-          <span className="LogsSummary__highlight">
-            {data.weekendAvg.toLocaleString("en-US", {
-              minimumFractionDigits: 0,
-              maximumFractionDigits: 2,
-            })}
-          </span>
-          , compared to weekdays where you averaged{" "}
-          <span className="LogsSummary__highlight">
-            {data.weekdayAvg.toLocaleString("en-US", {
-              minimumFractionDigits: 0,
-              maximumFractionDigits: 2,
-            })}
-          </span>
+          <strong>{currency}:</strong> weekend avg{" "}
+          <span className="LogsSummary__highlight">{num(data.weekendAvg)}</span>, weekday avg{" "}
+          <span className="LogsSummary__highlight">{num(data.weekdayAvg)}</span>
           {data.difference > 0 ? (
             <span>
               {" "}
-              (You spend{" "}
-              <span className="LogsSummary__highlight">
-                {data.difference.toLocaleString("en-US", {
-                  minimumFractionDigits: 0,
-                  maximumFractionDigits: 2,
-                })}
-              </span>{" "}
-              more on weekends)
+              — <span className="LogsSummary__highlight">{num(data.difference)}</span> more on
+              weekends
             </span>
           ) : data.difference < 0 ? (
             <span>
               {" "}
-              (You spend{" "}
-              <span className="LogsSummary__highlight">
-                {Math.abs(data.difference).toLocaleString("en-US", {
-                  minimumFractionDigits: 0,
-                  maximumFractionDigits: 2,
-                })}
+              — <span className="LogsSummary__highlight">
+                {num(Math.abs(data.difference))}
               </span>{" "}
-              more on weekdays)
+              more on weekdays
             </span>
           ) : (
-            <span> (You spend about the same regardless!)</span>
+            <span> — about the same</span>
           )}
         </div>
       ))}
@@ -576,13 +578,14 @@ const LowSpenderAlert = ({
   groupAnalytics?: GroupAnalytics;
   children: ReactNode;
 }) => {
-  const { dailyAverages } = useSpendingData();
+  const { dailyAverages, activeCurrency } = useSpendingData();
 
   if (!groupAnalytics) {
     return null; // Can't determine low spender status without group data
   }
 
   const lowSpenderCurrencies = [...dailyAverages.entries()]
+    .filter(currencyFilter(activeCurrency))
     .filter(([currency, userAvg]) => {
       const percentiles = groupAnalytics.currencyPercentiles.get(currency);
       return percentiles && userAvg <= percentiles.p25;

--- a/src/features/moneylog/components/LogsSummary/SpendingInsights.tsx
+++ b/src/features/moneylog/components/LogsSummary/SpendingInsights.tsx
@@ -269,7 +269,7 @@ const TotalText = ({ children }: { children: ReactNode }) => {
 
   return (
     <div className="LogsSummary__bubble">
-      <p>
+      <div>
         {children}{" "}
         <span className="LogsSummary__highlight">
           {[...totalSpent.entries()]
@@ -287,7 +287,7 @@ const TotalText = ({ children }: { children: ReactNode }) => {
           )}{" "}
           to {dayjs(group.end.seconds * 1000).format("ddd D MMM YYYY")}
         </span>
-      </p>
+      </div>
     </div>
   );
 };
@@ -302,7 +302,7 @@ const WeekText = ({ children }: { children: ReactNode }) => {
 
         if (expensiveWeeks.length === 1) {
           return (
-            <p>
+            <div>
               {children}{" "}
               <span className="LogsSummary__highlight">
                 {expensiveWeeks.map(
@@ -310,12 +310,12 @@ const WeekText = ({ children }: { children: ReactNode }) => {
                     `${value.week} (${value.amount.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${currency})`,
                 )}
               </span>
-            </p>
+            </div>
           );
         } else {
           return (
             <>
-              <p>{children}...</p>
+              <div>{children}...</div>
               <ul className="LogsSummary__List">
                 {expensiveWeeks.map(([currency, value]) => (
                   <li
@@ -351,7 +351,7 @@ const DayText = ({
 
         if (expensiveDays.length === 1) {
           return (
-            <p>
+            <div>
               {children}{" "}
               <span className="LogsSummary__highlight">
                 {expensiveDays.map(
@@ -359,12 +359,12 @@ const DayText = ({
                     `${value.day} (${value.amount.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${currency})`,
                 )}
               </span>
-            </p>
+            </div>
           );
         } else {
           return (
             <>
-              <p>{children}...</p>
+              <div>{children}...</div>
               <ul className="LogsSummary__List">
                 {expensiveDays.map(([currency, value]) => (
                   <li
@@ -379,9 +379,9 @@ const DayText = ({
 
       {showPosts && (
         <>
-          <p>
+          <div>
             <span>Some posts from then...</span>
-          </p>
+          </div>
 
           <div className="LogsSummary__ScrollList">
             {(() => {
@@ -478,7 +478,7 @@ const AveragesText = ({ children }: { children: ReactNode }) => {
 
   return (
     <div className="LogsSummary__bubble">
-      <p>{children}</p>
+      <div>{children}</div>
 
       {weeklyAverages.size > 0 && (
         <div>
@@ -518,7 +518,7 @@ const WeekendWeekdayText = ({ children }: { children: ReactNode }) => {
 
   return (
     <div className="LogsSummary__bubble">
-      <p>{children}</p>
+      <div>{children}</div>
 
       {[...weekendVsWeekdayDiff.entries()].map(([currency, data]) => (
         <div key={`weekend-weekday-${currency}`}>
@@ -595,11 +595,11 @@ const LowSpenderAlert = ({
 
   return (
     <div className="LogsSummary__bubble LogsSummary__bubble--alert">
-      <p>{children}</p>
-      <p>
+      <div>{children}</div>
+      <div>
         You're amongst the <span className="LogsSummary__highlight">lowest spenders</span> in:{" "}
         <span className="LogsSummary__highlight">{lowSpenderCurrencies.join(", ")}</span>
-      </p>
+      </div>
     </div>
   );
 };
@@ -611,7 +611,7 @@ const NoSpendDaysText = ({ children }: { children: ReactNode }) => {
 
   return (
     <div className="LogsSummary__bubble">
-      <p>
+      <div>
         {children}{" "}
         <span className="LogsSummary__highlight">
           {noSpendDays} out of {totalDaysInPeriod} days ({noSpendPercentage}%)
@@ -621,7 +621,7 @@ const NoSpendDaysText = ({ children }: { children: ReactNode }) => {
             {noSpendDays === 1 ? " - great self-control!" : " - excellent spending discipline!"}
           </span>
         )}
-      </p>
+      </div>
     </div>
   );
 };

--- a/src/features/moneylog/components/LogsSummary/SpendingInsights.tsx
+++ b/src/features/moneylog/components/LogsSummary/SpendingInsights.tsx
@@ -1,106 +1,121 @@
-import { useMemo, createContext, useContext, ReactNode } from "react"
-import dayjs from "dayjs"
-import MDEditor from "@uiw/react-md-editor"
+import { useMemo, createContext, useContext, ReactNode } from "react";
+import dayjs from "dayjs";
 
-import { Currency, Group, LogPost } from "@/types/user"
-import Icon from "@/components/Icon"
-import { FullUserData } from "@/hooks/useGetGroupUsers"
+import { Currency, Group, LogPost } from "@/types/user";
+import { FullUserData } from "@/hooks/useGetGroupUsers";
+import PostPreview from "./PostPreview";
 
 interface SpendingData {
-  totalSpent: Map<Currency, number>
-  expensiveWeek: Map<Currency, { week: string, amount: number }>
-  expensiveDay: Map<Currency, { day: string, amount: number, posts: LogPost[] }>
+  totalSpent: Map<Currency, number>;
+  expensiveWeek: Map<Currency, { week: string; amount: number }>;
+  expensiveDay: Map<Currency, { day: string; amount: number; posts: LogPost[] }>;
   // New analytics
-  weeklyAverages: Map<Currency, number>
-  dailyAverages: Map<Currency, number>
-  weekendVsWeekdayDiff: Map<Currency, { weekendAvg: number, weekdayAvg: number, difference: number }>
-  noSpendDays: number
-  totalDaysInPeriod: number
-  group: Group
+  weeklyAverages: Map<Currency, number>;
+  dailyAverages: Map<Currency, number>;
+  weekendVsWeekdayDiff: Map<
+    Currency,
+    { weekendAvg: number; weekdayAvg: number; difference: number }
+  >;
+  noSpendDays: number;
+  totalDaysInPeriod: number;
+  group: Group;
 }
 
 // New interface for group-wide analytics (passed from parent)
 interface GroupAnalytics {
-  currencyPercentiles: Map<Currency, { p25: number, p50: number, p75: number }>
+  currencyPercentiles: Map<Currency, { p25: number; p50: number; p75: number }>;
 }
 
-const SpendingContext = createContext<SpendingData | null>(null)
+const SpendingContext = createContext<SpendingData | null>(null);
 
 const useSpendingData = () => {
-  const context = useContext(SpendingContext)
+  const context = useContext(SpendingContext);
   if (!context) {
-    throw new Error('Spending components must be used within SpendingInsights')
+    throw new Error("Spending components must be used within SpendingInsights");
   }
-  return context
-}
+  return context;
+};
 
 interface SpendingInsightsProps {
-  user: Partial<FullUserData>
-  logPosts: Array<LogPost>
-  group: Group
-  groupAnalytics?: GroupAnalytics // Optional for now, for low-spender detection
-  children: ReactNode
+  user: Partial<FullUserData>;
+  logPosts: Array<LogPost>;
+  group: Group;
+  groupAnalytics?: GroupAnalytics; // Optional for now, for low-spender detection
+  children: ReactNode;
 }
 
-const SpendingInsights = ({ user, logPosts, group, groupAnalytics, children }: SpendingInsightsProps) => {
+const SpendingInsights = ({ user, logPosts, group, children }: SpendingInsightsProps) => {
   const spendingData = useMemo(() => {
-    const hasCachedAnalytics = group.analytics?.isCalculated
-    const postsMetadata = group.analytics?.posts
+    const hasCachedAnalytics = group.analytics?.isCalculated;
+    const postsMetadata = group.analytics?.posts;
 
-    const pinnedPostId = user?.pinnedPosts?.[group.id]?.pinnedPost
+    const pinnedPostId = user?.pinnedPosts?.[group.id]?.pinnedPost;
 
-    const groupStartDate = dayjs(group.start.seconds * 1000)
-    const groupEndDate = dayjs(group.end.seconds * 1000)
-    const totalDaysInPeriod = groupEndDate.diff(groupStartDate, 'day') + 1 // +1 to include both start and end dates
+    const groupStartDate = dayjs(group.start.seconds * 1000);
+    const groupEndDate = dayjs(group.end.seconds * 1000);
+    const totalDaysInPeriod = groupEndDate.diff(groupStartDate, "day") + 1; // +1 to include both start and end dates
 
-    const legitimatePosts = logPosts.filter(log => {
-      const postDate = dayjs(log.postDate.seconds * 1000)
-      const isNotPinnedPost = pinnedPostId ? log.id !== pinnedPostId : true
+    const legitimatePosts = logPosts.filter((log) => {
+      const postDate = dayjs(log.postDate.seconds * 1000);
+      const isNotPinnedPost = pinnedPostId ? log.id !== pinnedPostId : true;
 
-      return !postDate.isAfter(groupEndDate, 'day') && !postDate.isBefore(groupStartDate, 'day') &&isNotPinnedPost
-    })
+      return (
+        !postDate.isAfter(groupEndDate, "day") &&
+        !postDate.isBefore(groupStartDate, "day") &&
+        isNotPinnedPost
+      );
+    });
 
-    let totalSpent = new Map<Currency, number>()
-    let weeklyTotals = new Map<string, { currencyMap: Map<Currency, number>, date: dayjs.Dayjs }>()
-    let dailyTotals = new Map<string, { currencyMap: Map<Currency, number>, date: dayjs.Dayjs, posts: LogPost[] }>()
+    const totalSpent = new Map<Currency, number>();
+    const weeklyTotals = new Map<
+      string,
+      { currencyMap: Map<Currency, number>; date: dayjs.Dayjs }
+    >();
+    const dailyTotals = new Map<
+      string,
+      { currencyMap: Map<Currency, number>; date: dayjs.Dayjs; posts: LogPost[] }
+    >();
 
     // New: Weekend vs weekday tracking
-    let weekendTotals = new Map<Currency, { totalAmount: number, dayCount: number }>()
-    let weekdayTotals = new Map<Currency, { totalAmount: number, dayCount: number }>()
+    const weekendTotals = new Map<Currency, { totalAmount: number; dayCount: number }>();
+    const weekdayTotals = new Map<Currency, { totalAmount: number; dayCount: number }>();
 
-    legitimatePosts.forEach(log => {
-      let postDate: dayjs.Dayjs
+    legitimatePosts.forEach((log) => {
+      let postDate: dayjs.Dayjs;
       if (hasCachedAnalytics && postsMetadata?.[log.id]?.postTimezone) {
         // Use the timezone from cached analytics
-        const timezone = postsMetadata[log.id].postTimezone
-        postDate = dayjs(log.postDate.seconds * 1000).tz(timezone)
+        const timezone = postsMetadata[log.id].postTimezone;
+        postDate = dayjs(log.postDate.seconds * 1000).tz(timezone);
       } else {
         // Fallback to current behavior (browser timezone)
-        postDate = dayjs(log.postDate.seconds * 1000)
+        postDate = dayjs(log.postDate.seconds * 1000);
       }
 
-      const logPost = log
-      const currency = logPost.currency
+      const logPost = log;
+      const currency = logPost.currency;
 
       // Calculate total spent
-      let prevTotal = totalSpent.get(currency) || 0
-      totalSpent.set(currency, prevTotal + Number(logPost.amount))
+      const prevTotal = totalSpent.get(currency) || 0;
+      totalSpent.set(currency, prevTotal + Number(logPost.amount));
 
       // Generate keys for grouping - Monday as day 0
-      const dayOfWeek = postDate.day() === 0 ? 6 : postDate.day() - 1 // Convert Sunday=0 to Sunday=6, others shift down by 1
-      const mondayOfWeek = postDate.subtract(dayOfWeek, 'day')
-      const weekKey = mondayOfWeek.format('YYYY-MM-DD') // Use Monday's date as week key
-      const dayKey = postDate.format('YYYY-MM-DD')
+      const dayOfWeek = postDate.day() === 0 ? 6 : postDate.day() - 1; // Convert Sunday=0 to Sunday=6, others shift down by 1
+      const mondayOfWeek = postDate.subtract(dayOfWeek, "day");
+      const weekKey = mondayOfWeek.format("YYYY-MM-DD"); // Use Monday's date as week key
+      const dayKey = postDate.format("YYYY-MM-DD");
 
       // Track weekly totals
       if (!weeklyTotals.has(weekKey)) {
         weeklyTotals.set(weekKey, {
           currencyMap: new Map<Currency, number>(),
-          date: mondayOfWeek
-        })
+          date: mondayOfWeek,
+        });
       }
-      const weekData = weeklyTotals.get(weekKey)!
-      weekData.currencyMap.set(currency, (weekData.currencyMap.get(currency) || 0) + Number(log.amount))
+      const weekData = weeklyTotals.get(weekKey)!;
+      weekData.currencyMap.set(
+        currency,
+        (weekData.currencyMap.get(currency) || 0) + Number(log.amount),
+      );
 
       // Track daily totals
       if (!dailyTotals.has(dayKey)) {
@@ -108,122 +123,128 @@ const SpendingInsights = ({ user, logPosts, group, groupAnalytics, children }: S
           currencyMap: new Map<Currency, number>(),
           date: postDate,
           posts: [],
-        })
+        });
       }
-      const dayData = dailyTotals.get(dayKey)!
-      dayData.currencyMap.set(currency, (dayData.currencyMap.get(currency) || 0) + Number(log.amount))
-      dayData.posts = [...dayData.posts, logPost]
+      const dayData = dailyTotals.get(dayKey)!;
+      dayData.currencyMap.set(
+        currency,
+        (dayData.currencyMap.get(currency) || 0) + Number(log.amount),
+      );
+      dayData.posts = [...dayData.posts, logPost];
 
       // New: Weekend vs weekday tracking
-      const isWeekend = postDate.day() === 0 || postDate.day() === 6 // Sunday or Saturday
-      const targetMap = isWeekend ? weekendTotals : weekdayTotals
+      const isWeekend = postDate.day() === 0 || postDate.day() === 6; // Sunday or Saturday
+      const targetMap = isWeekend ? weekendTotals : weekdayTotals;
 
       if (!targetMap.has(currency)) {
-        targetMap.set(currency, { totalAmount: 0, dayCount: 0 })
+        targetMap.set(currency, { totalAmount: 0, dayCount: 0 });
       }
 
       // Only count each day once per currency (aggregate daily totals first)
       // const existingDayTotal = dailyTotals.get(dayKey)?.currencyMap.get(currency) || 0
       // We need to check if this is the first transaction for this day/currency combo
-      const isFirstTransactionOfDay = (dailyTotals.get(dayKey)?.currencyMap.get(currency) || 0) === log.amount
+      const isFirstTransactionOfDay =
+        (dailyTotals.get(dayKey)?.currencyMap.get(currency) || 0) === log.amount;
 
       if (isFirstTransactionOfDay) {
-        const currencyData = targetMap.get(currency)!
-        currencyData.dayCount += 1
+        const currencyData = targetMap.get(currency)!;
+        currencyData.dayCount += 1;
       }
-    })
+    });
 
     // After processing all transactions, finalize weekend/weekday totals by day
-    for (const [dayKey, dayData] of dailyTotals) {
-      const isWeekend = dayData.date.day() === 0 || dayData.date.day() === 6
-      const targetMap = isWeekend ? weekendTotals : weekdayTotals
+    for (const [, dayData] of dailyTotals) {
+      const isWeekend = dayData.date.day() === 0 || dayData.date.day() === 6;
+      const targetMap = isWeekend ? weekendTotals : weekdayTotals;
 
       for (const [currency, dayAmount] of dayData.currencyMap) {
         if (!targetMap.has(currency)) {
-          targetMap.set(currency, { totalAmount: 0, dayCount: 0 })
+          targetMap.set(currency, { totalAmount: 0, dayCount: 0 });
         }
-        const currencyData = targetMap.get(currency)!
-        currencyData.totalAmount += dayAmount
+        const currencyData = targetMap.get(currency)!;
+        currencyData.totalAmount += dayAmount;
       }
     }
 
     // Find most expensive week per currency (existing logic)
-    let expensiveWeek = new Map<Currency, { week: string, amount: number }>()
-    for (const [weekKey, weekData] of weeklyTotals) {
-      const weekStart = weekData.date
-      const weekEnd = weekStart.add(6, 'day')
-      const weekRange = `${weekStart.format('ddd D MMM YYYY')} to ${weekEnd.format('ddd D MMM YYYY')}`
+    const expensiveWeek = new Map<Currency, { week: string; amount: number }>();
+    for (const [, weekData] of weeklyTotals) {
+      const weekStart = weekData.date;
+      const weekEnd = weekStart.add(6, "day");
+      const weekRange = `${weekStart.format("ddd D MMM YYYY")} to ${weekEnd.format("ddd D MMM YYYY")}`;
 
       for (const [currency, amount] of weekData.currencyMap) {
-        const current = expensiveWeek.get(currency)
+        const current = expensiveWeek.get(currency);
         if (!current || amount > current.amount) {
-          expensiveWeek.set(currency, { week: weekRange, amount })
+          expensiveWeek.set(currency, { week: weekRange, amount });
         }
       }
     }
 
     // Find most expensive day per currency (existing logic)
-    let expensiveDay = new Map<Currency, { day: string, amount: number, posts: LogPost[] }>()
-    for (const [dayKey, dayData] of dailyTotals) {
-      const dayFormatted = dayData.date.format('ddd D MMM YYYY')
+    const expensiveDay = new Map<Currency, { day: string; amount: number; posts: LogPost[] }>();
+    for (const [, dayData] of dailyTotals) {
+      const dayFormatted = dayData.date.format("ddd D MMM YYYY");
 
       for (const [currency, amount] of dayData.currencyMap) {
-        const current = expensiveDay.get(currency)
+        const current = expensiveDay.get(currency);
         if (!current || amount > current.amount) {
-          expensiveDay.set(currency, { day: dayFormatted, amount, posts: dayData.posts })
+          expensiveDay.set(currency, { day: dayFormatted, amount, posts: dayData.posts });
         }
       }
     }
 
     // New: Calculate averages
-    const weeklyAverages = new Map<Currency, number>()
-    const dailyAverages = new Map<Currency, number>()
-    const weekendVsWeekdayDiff = new Map<Currency, { weekendAvg: number, weekdayAvg: number, difference: number }>()
+    const weeklyAverages = new Map<Currency, number>();
+    const dailyAverages = new Map<Currency, number>();
+    const weekendVsWeekdayDiff = new Map<
+      Currency,
+      { weekendAvg: number; weekdayAvg: number; difference: number }
+    >();
 
     // Get unique currencies
-    const currencies = new Set([...totalSpent.keys()])
+    const currencies = new Set(totalSpent.keys());
 
-    currencies.forEach(currency => {
-      const total = totalSpent.get(currency) || 0
-      const weekCount = new Set([...weeklyTotals.keys()]).size
-      const dayCount = dailyTotals.size > 0 ? totalDaysInPeriod : 0
+    currencies.forEach((currency) => {
+      const total = totalSpent.get(currency) || 0;
+      const weekCount = new Set(weeklyTotals.keys()).size;
+      const dayCount = dailyTotals.size > 0 ? totalDaysInPeriod : 0;
 
       // Weekly average
       if (weekCount > 0) {
-        weeklyAverages.set(currency, total / weekCount)
+        weeklyAverages.set(currency, total / weekCount);
       }
 
       // Daily average
       if (dayCount > 0) {
-        dailyAverages.set(currency, total / dayCount)
+        dailyAverages.set(currency, total / dayCount);
       }
 
       // Weekend vs weekday comparison
-      const weekendData = weekendTotals.get(currency)
-      const weekdayData = weekdayTotals.get(currency)
+      const weekendData = weekendTotals.get(currency);
+      const weekdayData = weekdayTotals.get(currency);
 
       if (weekendData && weekdayData && weekendData.dayCount > 0 && weekdayData.dayCount > 0) {
-        const weekendAvg = weekendData.totalAmount / weekendData.dayCount
-        const weekdayAvg = weekdayData.totalAmount / weekdayData.dayCount
-        const difference = weekendAvg - weekdayAvg
+        const weekendAvg = weekendData.totalAmount / weekendData.dayCount;
+        const weekdayAvg = weekdayData.totalAmount / weekdayData.dayCount;
+        const difference = weekendAvg - weekdayAvg;
 
         weekendVsWeekdayDiff.set(currency, {
           weekendAvg,
           weekdayAvg,
-          difference
-        })
+          difference,
+        });
       }
-    })
+    });
 
     // Count days with spending (any currency, any amount > 0)
-    console.log(dailyTotals)
-    const daysWithSpending = Array.from(dailyTotals.values()).filter(day => {
-      return Array.from(day.currencyMap.values()).some(amount => amount > 0);
-    }).length
+    const daysWithSpending = Array.from(dailyTotals.values()).filter((day) => {
+      return Array.from(day.currencyMap.values()).some((amount) => amount > 0);
+    }).length;
     // const noSpendDays = totalDaysInPeriod - daysWithSpending
-    const noSpendDays = Array.from(dailyTotals.values()).filter(day => {
-      return Array.from(day.currencyMap.values()).every(amount => amount === 0);
-    }).length
+    const noSpendDays = Array.from(dailyTotals.values()).filter((day) => {
+      return Array.from(day.currencyMap.values()).every((amount) => amount === 0);
+    }).length;
 
     return {
       totalSpent,
@@ -235,86 +256,124 @@ const SpendingInsights = ({ user, logPosts, group, groupAnalytics, children }: S
       daysWithSpending,
       noSpendDays,
       totalDaysInPeriod,
-      group
-    }
-  }, [logPosts, group])
+      group,
+    };
+  }, [logPosts, group]);
 
-  return (
-    <SpendingContext.Provider value={spendingData}>
-      {children}
-    </SpendingContext.Provider>
-  )
-}
+  return <SpendingContext.Provider value={spendingData}>{children}</SpendingContext.Provider>;
+};
 
 // Existing components (unchanged)
 const TotalText = ({ children }: { children: ReactNode }) => {
-  const { totalSpent, group } = useSpendingData()
+  const { totalSpent, group } = useSpendingData();
 
   return (
     <div className="LogsSummary__bubble">
       <p>
-        {children}{' '}
+        {children}{" "}
         <span className="LogsSummary__highlight">
           {[...totalSpent.entries()]
-            .filter(([currency, value]) => value > 0)
-            .map(([currency, value]) => `${value.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${currency}`)
-            .join(', ')
-          }
+            .filter(([, value]) => value > 0)
+            .map(
+              ([currency, value]) =>
+                `${value.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${currency}`,
+            )
+            .join(", ")}
         </span>
-        <span> in total over the period of {dayjs(group.start.seconds * 1000).format('ddd D MMM YYYY')} to {dayjs(group.end.seconds * 1000).format('ddd D MMM YYYY')}</span>
+        <span>
+          {" "}
+          in total over the period of {dayjs(group.start.seconds * 1000).format(
+            "ddd D MMM YYYY",
+          )}{" "}
+          to {dayjs(group.end.seconds * 1000).format("ddd D MMM YYYY")}
+        </span>
       </p>
     </div>
-  )
-}
+  );
+};
 
 const WeekText = ({ children }: { children: ReactNode }) => {
-  const { expensiveWeek } = useSpendingData()
+  const { expensiveWeek } = useSpendingData();
 
   return (
     <div className="LogsSummary__bubble">
       {(() => {
-        const expensiveWeeks = [...expensiveWeek.entries()].filter(([currency, value]) => value.amount > 0)
+        const expensiveWeeks = [...expensiveWeek.entries()].filter(([, value]) => value.amount > 0);
 
         if (expensiveWeeks.length === 1) {
           return (
-            <p>{children}{' '}
-              <span className="LogsSummary__highlight">{expensiveWeeks.map(([currency, value]) => `${value.week} (${value.amount.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${currency})`)}</span>
+            <p>
+              {children}{" "}
+              <span className="LogsSummary__highlight">
+                {expensiveWeeks.map(
+                  ([currency, value]) =>
+                    `${value.week} (${value.amount.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${currency})`,
+                )}
+              </span>
             </p>
-          )
+          );
         } else {
           return (
             <>
               <p>{children}...</p>
-              <ul className="LogsSummary__List">{expensiveWeeks.map(([currency, value]) => <li key={`w-${currency}__${value.amount}`}>{`${value.week} (${value.amount.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${currency})`}</li>)}</ul>
+              <ul className="LogsSummary__List">
+                {expensiveWeeks.map(([currency, value]) => (
+                  <li
+                    key={`w-${currency}__${value.amount}`}
+                  >{`${value.week} (${value.amount.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${currency})`}</li>
+                ))}
+              </ul>
             </>
-          )
+          );
         }
       })()}
     </div>
-  )
-}
+  );
+};
 
-const DayText = ({ children, showPosts = true, showAuthors = false, showMultipleDays = false }: { children: ReactNode, showPosts?: boolean, showAuthors?: boolean, showMultipleDays?: boolean }) => {
-  const { expensiveDay } = useSpendingData()
+const DayText = ({
+  children,
+  showPosts = true,
+  showAuthors = false,
+  showMultipleDays = false,
+}: {
+  children: ReactNode;
+  showPosts?: boolean;
+  showAuthors?: boolean;
+  showMultipleDays?: boolean;
+}) => {
+  const { expensiveDay } = useSpendingData();
 
   return (
     <div className="LogsSummary__bubble">
       {(() => {
-        const expensiveDays = [...expensiveDay.entries()].filter(([currency, value]) => value.amount > 0)
+        const expensiveDays = [...expensiveDay.entries()].filter(([, value]) => value.amount > 0);
 
         if (expensiveDays.length === 1) {
           return (
-            <p>{children}{' '}
-              <span className="LogsSummary__highlight">{expensiveDays.map(([currency, value]) => `${value.day} (${value.amount.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${currency})`)}</span>
+            <p>
+              {children}{" "}
+              <span className="LogsSummary__highlight">
+                {expensiveDays.map(
+                  ([currency, value]) =>
+                    `${value.day} (${value.amount.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${currency})`,
+                )}
+              </span>
             </p>
-          )
+          );
         } else {
           return (
             <>
               <p>{children}...</p>
-              <ul className="LogsSummary__List">{expensiveDays.map(([currency, value]) => <li key={`d-${currency}__${value.amount}`}>{`${value.day} (${value.amount.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${currency})`}</li>)}</ul>
+              <ul className="LogsSummary__List">
+                {expensiveDays.map(([currency, value]) => (
+                  <li
+                    key={`d-${currency}__${value.amount}`}
+                  >{`${value.day} (${value.amount.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${currency})`}</li>
+                ))}
+              </ul>
             </>
-          )
+          );
         }
       })()}
 
@@ -327,93 +386,95 @@ const DayText = ({ children, showPosts = true, showAuthors = false, showMultiple
           <div className="LogsSummary__ScrollList">
             {(() => {
               // Find the single most expensive day across all currencies
-              const expensiveEntries = [...expensiveDay.entries()]
-                .filter(([currency, value]) => value.amount > 0)
+              const expensiveEntries = [...expensiveDay.entries()].filter(
+                ([, value]) => value.amount > 0,
+              );
 
-              if (expensiveEntries.length === 0) return null
+              if (expensiveEntries.length === 0) return null;
 
               const mostExpensiveEntry = expensiveEntries.reduce((max, current) =>
-                current[1].amount > max[1].amount ? current : max
-              )
+                current[1].amount > max[1].amount ? current : max,
+              );
 
-              const someExpensivePosts = expensiveEntries.map(x => x[1].posts).flat().filter(x => x.amount > 0)
+              const someExpensivePosts = expensiveEntries
+                .map((x) => x[1].posts)
+                .flat()
+                .filter((x) => x.amount > 0);
 
               // Get posts to display (either from multiple days or single most expensive day)
-              const postsToShow = showMultipleDays ? someExpensivePosts : mostExpensiveEntry[1].posts
+              const postsToShow = showMultipleDays
+                ? someExpensivePosts
+                : mostExpensiveEntry[1].posts;
 
               // Group posts by currency to handle comparison properly
-              const postsByCurrency = new Map<Currency, LogPost[]>()
-              postsToShow.forEach(post => {
+              const postsByCurrency = new Map<Currency, LogPost[]>();
+              postsToShow.forEach((post) => {
                 if (!postsByCurrency.has(post.currency)) {
-                  postsByCurrency.set(post.currency, [])
+                  postsByCurrency.set(post.currency, []);
                 }
-                postsByCurrency.get(post.currency)!.push(post)
-              })
+                postsByCurrency.get(post.currency)!.push(post);
+              });
 
               // Get top posts per currency, then combine
-              const topPostsPerCurrency: LogPost[] = []
-              const postsPerCurrency = Math.max(1, Math.floor(10 / postsByCurrency.size)) // Distribute the 10 slots
+              const topPostsPerCurrency: LogPost[] = [];
+              const postsPerCurrency = Math.max(1, Math.floor(10 / postsByCurrency.size)); // Distribute the 10 slots
 
-              postsByCurrency.forEach((currencyPosts, currency) => {
+              postsByCurrency.forEach((currencyPosts) => {
                 // Remove duplicates within this currency
-                const uniqueCurrencyPosts = currencyPosts.filter((post, index, array) =>
-                  array.findIndex(p => p.id === post.id) === index
-                )
+                const uniqueCurrencyPosts = currencyPosts.filter(
+                  (post, index, array) => array.findIndex((p) => p.id === post.id) === index,
+                );
 
                 // Sort by amount within currency and take top N for this currency
                 const topForCurrency = uniqueCurrencyPosts
                   .sort((a, b) => b.amount - a.amount)
-                  .slice(0, postsPerCurrency)
+                  .slice(0, postsPerCurrency);
 
-                topPostsPerCurrency.push(...topForCurrency)
-              })
+                topPostsPerCurrency.push(...topForCurrency);
+              });
 
               // If we have leftover slots, fill them with the next highest from any currency
               if (topPostsPerCurrency.length < 10) {
                 const remainingPosts = postsToShow
-                  .filter(post => !topPostsPerCurrency.some(tp => tp.id === post.id))
-                  .filter((post, index, array) => array.findIndex(p => p.id === post.id) === index) // dedupe
+                  .filter((post) => !topPostsPerCurrency.some((tp) => tp.id === post.id))
+                  .filter(
+                    (post, index, array) => array.findIndex((p) => p.id === post.id) === index,
+                  ); // dedupe
 
                 // Sort remaining posts by relative rank within their currency
-                const remainingWithRank = remainingPosts.map(post => {
-                  const currencyPosts = postsByCurrency.get(post.currency) || []
+                const remainingWithRank = remainingPosts.map((post) => {
+                  const currencyPosts = postsByCurrency.get(post.currency) || [];
                   const sortedCurrencyPosts = currencyPosts
-                    .filter((p, i, arr) => arr.findIndex(x => x.id === p.id) === i)
-                    .sort((a, b) => b.amount - a.amount)
-                  const rank = sortedCurrencyPosts.findIndex(p => p.id === post.id)
-                  return { post, rank, percentile: rank / sortedCurrencyPosts.length }
-                })
+                    .filter((p, i, arr) => arr.findIndex((x) => x.id === p.id) === i)
+                    .sort((a, b) => b.amount - a.amount);
+                  const rank = sortedCurrencyPosts.findIndex((p) => p.id === post.id);
+                  return { post, rank, percentile: rank / sortedCurrencyPosts.length };
+                });
 
                 const additionalPosts = remainingWithRank
                   .sort((a, b) => a.percentile - b.percentile) // Best rank/percentile first
                   .slice(0, 10 - topPostsPerCurrency.length)
-                  .map(x => x.post)
+                  .map((x) => x.post);
 
-                topPostsPerCurrency.push(...additionalPosts)
+                topPostsPerCurrency.push(...additionalPosts);
               }
 
-              const topExpensivePosts = topPostsPerCurrency
+              const topExpensivePosts = topPostsPerCurrency;
 
-              return topExpensivePosts.map(post =>
-                <div key={`PreviewPost__${post.id}`} className="PostPreview" data-color-mode="light">
-                  <div className="PostPreview__header">
-                    <strong>{post.amount.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 })} {post.currency}</strong>
-                  </div>
-                  <MDEditor.Markdown source={post.content} />
-                  {showAuthors && <div className="PostPreview__footer"><Icon type={"user"} />{post.authorName}</div>}
-                </div>
-              )
+              return topExpensivePosts.map((post) => (
+                <PostPreview key={`PreviewPost__${post.id}`} post={post} showAuthor={showAuthors} />
+              ));
             })()}
           </div>
         </>
       )}
     </div>
-  )
-}
+  );
+};
 
 // New components for the additional analytics
 const AveragesText = ({ children }: { children: ReactNode }) => {
-  const { weeklyAverages, dailyAverages } = useSpendingData()
+  const { weeklyAverages, dailyAverages } = useSpendingData();
 
   return (
     <div className="LogsSummary__bubble">
@@ -421,35 +482,39 @@ const AveragesText = ({ children }: { children: ReactNode }) => {
 
       {weeklyAverages.size > 0 && (
         <div>
-          <strong>Weekly averages:</strong>{' '}
+          <strong>Weekly averages:</strong>{" "}
           <span className="LogsSummary__highlight">
             {[...weeklyAverages.entries()]
-              .map(([currency, avg]) => `${avg.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${currency}`)
-              .join(', ')
-            }
+              .map(
+                ([currency, avg]) =>
+                  `${avg.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${currency}`,
+              )
+              .join(", ")}
           </span>
         </div>
       )}
 
       {dailyAverages.size > 0 && (
         <div>
-          <strong>Daily averages:</strong>{' '}
+          <strong>Daily averages:</strong>{" "}
           <span className="LogsSummary__highlight">
             {[...dailyAverages.entries()]
-              .map(([currency, avg]) => `${avg.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${currency}`)
-              .join(', ')
-            }
+              .map(
+                ([currency, avg]) =>
+                  `${avg.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${currency}`,
+              )
+              .join(", ")}
           </span>
         </div>
       )}
     </div>
-  )
-}
+  );
+};
 
 const WeekendWeekdayText = ({ children }: { children: ReactNode }) => {
-  const { weekendVsWeekdayDiff } = useSpendingData()
+  const { weekendVsWeekdayDiff } = useSpendingData();
 
-  if (weekendVsWeekdayDiff.size === 0) return
+  if (weekendVsWeekdayDiff.size === 0) return;
 
   return (
     <div className="LogsSummary__bubble">
@@ -457,79 +522,117 @@ const WeekendWeekdayText = ({ children }: { children: ReactNode }) => {
 
       {[...weekendVsWeekdayDiff.entries()].map(([currency, data]) => (
         <div key={`weekend-weekday-${currency}`}>
-          <strong>{currency}:</strong>{' '}
-            On weekends you spent an average of <span className="LogsSummary__highlight">{data.weekendAvg.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 })}</span>, compared to weekdays where you averaged <span className="LogsSummary__highlight">{data.weekdayAvg.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 })}</span>
+          <strong>{currency}:</strong> On weekends you spent an average of{" "}
+          <span className="LogsSummary__highlight">
+            {data.weekendAvg.toLocaleString("en-US", {
+              minimumFractionDigits: 0,
+              maximumFractionDigits: 2,
+            })}
+          </span>
+          , compared to weekdays where you averaged{" "}
+          <span className="LogsSummary__highlight">
+            {data.weekdayAvg.toLocaleString("en-US", {
+              minimumFractionDigits: 0,
+              maximumFractionDigits: 2,
+            })}
+          </span>
           {data.difference > 0 ? (
-            <span> (You spend <span className="LogsSummary__highlight">{data.difference.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 })}</span> more on weekends)</span>
+            <span>
+              {" "}
+              (You spend{" "}
+              <span className="LogsSummary__highlight">
+                {data.difference.toLocaleString("en-US", {
+                  minimumFractionDigits: 0,
+                  maximumFractionDigits: 2,
+                })}
+              </span>{" "}
+              more on weekends)
+            </span>
           ) : data.difference < 0 ? (
-            <span> (You spend <span className="LogsSummary__highlight">{Math.abs(data.difference).toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 })}</span> more on weekdays)</span>
+            <span>
+              {" "}
+              (You spend{" "}
+              <span className="LogsSummary__highlight">
+                {Math.abs(data.difference).toLocaleString("en-US", {
+                  minimumFractionDigits: 0,
+                  maximumFractionDigits: 2,
+                })}
+              </span>{" "}
+              more on weekdays)
+            </span>
           ) : (
             <span> (You spend about the same regardless!)</span>
           )}
         </div>
       ))}
     </div>
-  )
-}
+  );
+};
 
-const LowSpenderAlert = ({ groupAnalytics, children }: { groupAnalytics?: GroupAnalytics, children: ReactNode }) => {
-  const { dailyAverages } = useSpendingData()
+const LowSpenderAlert = ({
+  groupAnalytics,
+  children,
+}: {
+  groupAnalytics?: GroupAnalytics;
+  children: ReactNode;
+}) => {
+  const { dailyAverages } = useSpendingData();
 
   if (!groupAnalytics) {
-    return null // Can't determine low spender status without group data
+    return null; // Can't determine low spender status without group data
   }
 
   const lowSpenderCurrencies = [...dailyAverages.entries()]
     .filter(([currency, userAvg]) => {
-      const percentiles = groupAnalytics.currencyPercentiles.get(currency)
-      return percentiles && userAvg <= percentiles.p25
+      const percentiles = groupAnalytics.currencyPercentiles.get(currency);
+      return percentiles && userAvg <= percentiles.p25;
     })
-    .map(([currency]) => currency)
+    .map(([currency]) => currency);
 
   if (lowSpenderCurrencies.length === 0) {
-    return null
+    return null;
   }
 
   return (
     <div className="LogsSummary__bubble LogsSummary__bubble--alert">
       <p>{children}</p>
       <p>
-        You're amongst the <span className="LogsSummary__highlight">lowest spenders</span> in: <span className="LogsSummary__highlight">{lowSpenderCurrencies.join(', ')}</span>
+        You're amongst the <span className="LogsSummary__highlight">lowest spenders</span> in:{" "}
+        <span className="LogsSummary__highlight">{lowSpenderCurrencies.join(", ")}</span>
       </p>
     </div>
-  )
-}
+  );
+};
 
 const NoSpendDaysText = ({ children }: { children: ReactNode }) => {
-  const { noSpendDays, totalDaysInPeriod } = useSpendingData()
+  const { noSpendDays, totalDaysInPeriod } = useSpendingData();
 
-  const noSpendPercentage = ((noSpendDays / totalDaysInPeriod) * 100).toFixed(1)
+  const noSpendPercentage = ((noSpendDays / totalDaysInPeriod) * 100).toFixed(1);
 
   return (
     <div className="LogsSummary__bubble">
       <p>
-        {children}{' '}
+        {children}{" "}
         <span className="LogsSummary__highlight">
           {noSpendDays} out of {totalDaysInPeriod} days ({noSpendPercentage}%)
         </span>
-        {noSpendDays === 0 && <span> ... 😅</span>}
         {noSpendDays > 0 && (
           <span>
-            {noSpendDays === 1 ? ' - great self-control!' : ' - excellent spending discipline!'}
+            {noSpendDays === 1 ? " - great self-control!" : " - excellent spending discipline!"}
           </span>
         )}
       </p>
     </div>
-  )
-}
+  );
+};
 
 // Attach sub-components to main component
-SpendingInsights.NoSpendDaysText = NoSpendDaysText
-SpendingInsights.TotalText = TotalText
-SpendingInsights.WeekText = WeekText
-SpendingInsights.DayText = DayText
-SpendingInsights.AveragesText = AveragesText
-SpendingInsights.WeekendWeekdayText = WeekendWeekdayText
-SpendingInsights.LowSpenderAlert = LowSpenderAlert
+SpendingInsights.NoSpendDaysText = NoSpendDaysText;
+SpendingInsights.TotalText = TotalText;
+SpendingInsights.WeekText = WeekText;
+SpendingInsights.DayText = DayText;
+SpendingInsights.AveragesText = AveragesText;
+SpendingInsights.WeekendWeekdayText = WeekendWeekdayText;
+SpendingInsights.LowSpenderAlert = LowSpenderAlert;
 
-export default SpendingInsights
+export default SpendingInsights;

--- a/src/features/moneylog/components/LogsSummary/SpendingPanel.tsx
+++ b/src/features/moneylog/components/LogsSummary/SpendingPanel.tsx
@@ -26,35 +26,11 @@ const fmt = (value: number, currency: Currency) =>
   `${value.toLocaleString("en-US", { maximumFractionDigits: 2 })} ${currency}`;
 
 const insightsChildren = (scope: Scope, groupAnalytics?: GroupAnalytics): ReactNode => {
-  if (scope === "group") {
-    return (
-      <>
-        <div className="SpendingInsights__grid">
-          <SpendingInsights.TotalText>
-            The group spent a <strong>total of</strong>
-          </SpendingInsights.TotalText>
-          <SpendingInsights.WeekText>
-            The group <strong>spent the most</strong> during the <strong>weeks of</strong>
-          </SpendingInsights.WeekText>
-        </div>
-        <SpendingInsights.DayText showPosts={true} showAuthors={true} showMultipleDays={true}>
-          The <strong>days the group spent the most</strong> were
-        </SpendingInsights.DayText>
-      </>
-    );
-  }
-
   const subject = scope === "mine" ? "You" : "This user";
   const possessive = scope === "mine" ? "your" : "this user's";
   return (
     <>
       <div className="SpendingInsights__grid">
-        <SpendingInsights.TotalText>
-          {subject} spent a <strong>total of</strong>
-        </SpendingInsights.TotalText>
-        <SpendingInsights.WeekText>
-          {subject} <strong>spent the most</strong> during the <strong>week(s) of</strong>
-        </SpendingInsights.WeekText>
         <SpendingInsights.AveragesText>
           Here are {possessive} average <strong>spending patterns</strong>:
         </SpendingInsights.AveragesText>
@@ -66,10 +42,6 @@ const insightsChildren = (scope: Scope, groupAnalytics?: GroupAnalytics): ReactN
           <strong>Good news!</strong>
         </SpendingInsights.LowSpenderAlert>
       </div>
-      <SpendingInsights.DayText showPosts={true} showAuthors={scope === "other"}>
-        The <strong>{scope === "mine" ? "day you spent the most" : "most expensive day"}</strong>{" "}
-        was
-      </SpendingInsights.DayText>
     </>
   );
 };

--- a/src/features/moneylog/components/LogsSummary/SpendingPanel.tsx
+++ b/src/features/moneylog/components/LogsSummary/SpendingPanel.tsx
@@ -1,0 +1,172 @@
+import { ReactNode, useMemo, useState } from "react";
+import { Currency, Group, LogPost } from "@/types/user";
+import { FullUserData } from "@/hooks/useGetGroupUsers";
+import Button from "@/components/Button";
+import SpendingInsights from "./SpendingInsights";
+import SpendingChart from "./SpendingChart";
+import PostPreview from "./PostPreview";
+import { autoGranularity, buildSpendingSeries } from "./spendingSeries";
+
+type Scope = "mine" | "group" | "other";
+type ChartMode = "bars" | "cumulative";
+
+interface GroupAnalytics {
+  currencyPercentiles: Map<Currency, { p25: number; p50: number; p75: number }>;
+}
+
+interface SpendingPanelProps {
+  user: Partial<FullUserData>;
+  logPosts: LogPost[];
+  group: Group;
+  scope: Scope;
+  groupAnalytics?: GroupAnalytics;
+}
+
+const fmt = (value: number, currency: Currency) =>
+  `${value.toLocaleString("en-US", { maximumFractionDigits: 2 })} ${currency}`;
+
+const insightsChildren = (scope: Scope, groupAnalytics?: GroupAnalytics): ReactNode => {
+  if (scope === "group") {
+    return (
+      <>
+        <SpendingInsights.TotalText>
+          The group spent a <strong>total of</strong>
+        </SpendingInsights.TotalText>
+        <SpendingInsights.WeekText>
+          The group <strong>spent the most</strong> during the <strong>weeks of</strong>
+        </SpendingInsights.WeekText>
+        <SpendingInsights.DayText showPosts={true} showAuthors={true} showMultipleDays={true}>
+          The <strong>days the group spent the most</strong> were
+        </SpendingInsights.DayText>
+      </>
+    );
+  }
+
+  const subject = scope === "mine" ? "You" : "This user";
+  const possessive = scope === "mine" ? "your" : "this user's";
+  return (
+    <>
+      <SpendingInsights.TotalText>
+        {subject} spent a <strong>total of</strong>
+      </SpendingInsights.TotalText>
+      <SpendingInsights.WeekText>
+        {subject} <strong>spent the most</strong> during the <strong>week(s) of</strong>
+      </SpendingInsights.WeekText>
+      <SpendingInsights.DayText showPosts={true} showAuthors={scope === "other"}>
+        The <strong>{scope === "mine" ? "day you spent the most" : "most expensive day"}</strong>{" "}
+        was
+      </SpendingInsights.DayText>
+      <SpendingInsights.AveragesText>
+        Here are {possessive} average <strong>spending patterns</strong>:
+      </SpendingInsights.AveragesText>
+      <SpendingInsights.WeekendWeekdayText>{""}</SpendingInsights.WeekendWeekdayText>
+      <SpendingInsights.NoSpendDaysText>
+        {subject} logged <strong>no spending</strong> on
+      </SpendingInsights.NoSpendDaysText>
+      <SpendingInsights.LowSpenderAlert groupAnalytics={groupAnalytics}>
+        <strong>Good news!</strong>
+      </SpendingInsights.LowSpenderAlert>
+    </>
+  );
+};
+
+const SpendingPanel = ({ user, logPosts, group, scope, groupAnalytics }: SpendingPanelProps) => {
+  const granularity = useMemo(() => autoGranularity(group), [group]);
+  const spending = useMemo(
+    () => buildSpendingSeries(logPosts, group, { user, granularity }),
+    [logPosts, group, user, granularity],
+  );
+
+  const [mode, setMode] = useState<ChartMode>("bars");
+  const [currency, setCurrency] = useState<Currency | null>(null);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+
+  const { currencies } = spending;
+  const activeCurrency =
+    currency && currencies.includes(currency) ? currency : (currencies[0] ?? null);
+
+  const points = activeCurrency ? (spending.series.get(activeCurrency) ?? []) : [];
+  const selectedPoint = selectedKey ? points.find((p) => p.key === selectedKey) : undefined;
+
+  return (
+    <div className="SpendingPanel">
+      {currencies.length === 0 || !activeCurrency ? (
+        <p className="SpendingPanel__empty">No spending was logged in this period.</p>
+      ) : (
+        <>
+          <div className="SpendingPanel__controls">
+            <div className="Segmented" role="group" aria-label="Graph type">
+              <Button
+                text="bars"
+                size="sm"
+                buttonStyle="primary-border"
+                isSelected={mode === "bars"}
+                onClick={() => setMode("bars")}
+              />
+              <Button
+                text="cumulative"
+                size="sm"
+                buttonStyle="primary-border"
+                isSelected={mode === "cumulative"}
+                onClick={() => setMode("cumulative")}
+              />
+            </div>
+
+            {currencies.length > 1 && (
+              <div className="Segmented" role="group" aria-label="Currency">
+                {currencies.map((c) => (
+                  <Button
+                    key={c}
+                    text={c}
+                    size="sm"
+                    buttonStyle="primary-border"
+                    isSelected={c === activeCurrency}
+                    onClick={() => {
+                      setCurrency(c);
+                      setSelectedKey(null);
+                    }}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+
+          <SpendingChart
+            series={points}
+            mode={mode}
+            currency={activeCurrency}
+            selectedKey={selectedKey}
+            onSelectPoint={(p) => setSelectedKey((k) => (k === p.key ? null : p.key))}
+          />
+
+          {selectedPoint && selectedPoint.posts.length > 0 && (
+            <div className="SpendingPanel__daydetail">
+              <p>
+                <strong>{selectedPoint.label}</strong> — {fmt(selectedPoint.amount, activeCurrency)}
+              </p>
+              <div className="LogsSummary__ScrollList">
+                {[...selectedPoint.posts]
+                  .sort((a, b) => b.amount - a.amount)
+                  .slice(0, 10)
+                  .map((post) => (
+                    <PostPreview key={`sel-${post.id}`} post={post} showAuthor={scope !== "mine"} />
+                  ))}
+              </div>
+            </div>
+          )}
+
+          <SpendingInsights
+            user={user}
+            logPosts={logPosts}
+            group={group}
+            groupAnalytics={groupAnalytics}
+          >
+            {insightsChildren(scope, groupAnalytics)}
+          </SpendingInsights>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default SpendingPanel;

--- a/src/features/moneylog/components/LogsSummary/SpendingPanel.tsx
+++ b/src/features/moneylog/components/LogsSummary/SpendingPanel.tsx
@@ -26,8 +26,8 @@ const fmt = (value: number, currency: Currency) =>
   `${value.toLocaleString("en-US", { maximumFractionDigits: 2 })} ${currency}`;
 
 const insightsChildren = (scope: Scope, groupAnalytics?: GroupAnalytics): ReactNode => {
-  const subject = scope === "mine" ? "You" : "This user";
-  const possessive = scope === "mine" ? "your" : "this user's";
+  const subject = scope === "mine" ? "You" : scope === "group" ? "The group" : "This user";
+  const possessive = scope === "mine" ? "your" : scope === "group" ? "the group's" : "this user's";
   return (
     <>
       <div className="SpendingInsights__grid">
@@ -136,6 +136,7 @@ const SpendingPanel = ({ user, logPosts, group, scope, groupAnalytics }: Spendin
             logPosts={logPosts}
             group={group}
             groupAnalytics={groupAnalytics}
+            currency={activeCurrency}
           >
             {insightsChildren(scope, groupAnalytics)}
           </SpendingInsights>

--- a/src/features/moneylog/components/LogsSummary/SpendingPanel.tsx
+++ b/src/features/moneylog/components/LogsSummary/SpendingPanel.tsx
@@ -29,12 +29,14 @@ const insightsChildren = (scope: Scope, groupAnalytics?: GroupAnalytics): ReactN
   if (scope === "group") {
     return (
       <>
-        <SpendingInsights.TotalText>
-          The group spent a <strong>total of</strong>
-        </SpendingInsights.TotalText>
-        <SpendingInsights.WeekText>
-          The group <strong>spent the most</strong> during the <strong>weeks of</strong>
-        </SpendingInsights.WeekText>
+        <div className="SpendingInsights__grid">
+          <SpendingInsights.TotalText>
+            The group spent a <strong>total of</strong>
+          </SpendingInsights.TotalText>
+          <SpendingInsights.WeekText>
+            The group <strong>spent the most</strong> during the <strong>weeks of</strong>
+          </SpendingInsights.WeekText>
+        </div>
         <SpendingInsights.DayText showPosts={true} showAuthors={true} showMultipleDays={true}>
           The <strong>days the group spent the most</strong> were
         </SpendingInsights.DayText>
@@ -46,26 +48,28 @@ const insightsChildren = (scope: Scope, groupAnalytics?: GroupAnalytics): ReactN
   const possessive = scope === "mine" ? "your" : "this user's";
   return (
     <>
-      <SpendingInsights.TotalText>
-        {subject} spent a <strong>total of</strong>
-      </SpendingInsights.TotalText>
-      <SpendingInsights.WeekText>
-        {subject} <strong>spent the most</strong> during the <strong>week(s) of</strong>
-      </SpendingInsights.WeekText>
+      <div className="SpendingInsights__grid">
+        <SpendingInsights.TotalText>
+          {subject} spent a <strong>total of</strong>
+        </SpendingInsights.TotalText>
+        <SpendingInsights.WeekText>
+          {subject} <strong>spent the most</strong> during the <strong>week(s) of</strong>
+        </SpendingInsights.WeekText>
+        <SpendingInsights.AveragesText>
+          Here are {possessive} average <strong>spending patterns</strong>:
+        </SpendingInsights.AveragesText>
+        <SpendingInsights.WeekendWeekdayText>{""}</SpendingInsights.WeekendWeekdayText>
+        <SpendingInsights.NoSpendDaysText>
+          {subject} logged <strong>no spending</strong> on
+        </SpendingInsights.NoSpendDaysText>
+        <SpendingInsights.LowSpenderAlert groupAnalytics={groupAnalytics}>
+          <strong>Good news!</strong>
+        </SpendingInsights.LowSpenderAlert>
+      </div>
       <SpendingInsights.DayText showPosts={true} showAuthors={scope === "other"}>
         The <strong>{scope === "mine" ? "day you spent the most" : "most expensive day"}</strong>{" "}
         was
       </SpendingInsights.DayText>
-      <SpendingInsights.AveragesText>
-        Here are {possessive} average <strong>spending patterns</strong>:
-      </SpendingInsights.AveragesText>
-      <SpendingInsights.WeekendWeekdayText>{""}</SpendingInsights.WeekendWeekdayText>
-      <SpendingInsights.NoSpendDaysText>
-        {subject} logged <strong>no spending</strong> on
-      </SpendingInsights.NoSpendDaysText>
-      <SpendingInsights.LowSpenderAlert groupAnalytics={groupAnalytics}>
-        <strong>Good news!</strong>
-      </SpendingInsights.LowSpenderAlert>
     </>
   );
 };

--- a/src/features/moneylog/components/LogsSummary/__tests__/SpendingChart.test.tsx
+++ b/src/features/moneylog/components/LogsSummary/__tests__/SpendingChart.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vite-plus/test";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import "@/utils/configuredDayjs";
+import SpendingChart from "@/features/moneylog/components/LogsSummary/SpendingChart";
+import { buildSpendingSeries } from "@/features/moneylog/components/LogsSummary/spendingSeries";
+import type { Group, LogPost } from "@/types/user";
+
+const JAN = (day: number) => 1705320000 + (day - 15) * 86400; // Jan 15 12:00 UTC
+const group = {
+  id: "g1",
+  start: { seconds: JAN(15) },
+  end: { seconds: JAN(19) },
+} as unknown as Group;
+
+const makePost = (amount: number, day: number): LogPost =>
+  ({
+    id: `p-${day}-${amount}`,
+    author: { id: "u1" },
+    authorName: "A",
+    currency: "CAD",
+    amount,
+    postDate: { seconds: JAN(day) },
+    content: "x",
+    groupId: "g1",
+  }) as unknown as LogPost;
+
+const points = () =>
+  buildSpendingSeries([makePost(100, 16), makePost(40, 18)], group, {
+    granularity: "day",
+  }).series.get("CAD")!;
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("SpendingChart", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders a bar and a hit target per bucket in bars mode", () => {
+    act(() => root.render(<SpendingChart series={points()} mode="bars" currency="CAD" />));
+    expect(container.querySelectorAll(".SpendingChart__bar")).toHaveLength(5);
+    expect(container.querySelectorAll(".SpendingChart__hit")).toHaveLength(5);
+    expect(container.querySelector(".SpendingChart__axis")).not.toBeNull();
+    expect(container.querySelector(".SpendingChart__line")).toBeNull();
+  });
+
+  it("renders a line path in cumulative mode", () => {
+    act(() => root.render(<SpendingChart series={points()} mode="cumulative" currency="CAD" />));
+    const line = container.querySelector<SVGPathElement>(".SpendingChart__line");
+    expect(line).not.toBeNull();
+    expect(line!.getAttribute("d")).toBeTruthy();
+    expect(container.querySelectorAll(".SpendingChart__bar")).toHaveLength(0);
+  });
+
+  it("shows a tooltip on hover and fires onSelectPoint on click", () => {
+    const onSelect = vi.fn();
+    act(() =>
+      root.render(
+        <SpendingChart series={points()} mode="bars" currency="CAD" onSelectPoint={onSelect} />,
+      ),
+    );
+    const hits = container.querySelectorAll<SVGRectElement>(".SpendingChart__hit");
+    // bucket index 1 == Jan 16 (100 CAD)
+    act(() => {
+      hits[1].dispatchEvent(
+        new MouseEvent("mousemove", { bubbles: true, clientX: 10, clientY: 10 }),
+      );
+    });
+    const tooltip = container.querySelector(".SpendingChart__tooltip");
+    expect(tooltip).not.toBeNull();
+    expect(tooltip!.textContent).toContain("100 CAD");
+
+    act(() => hits[1].dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0].amount).toBe(100);
+  });
+});

--- a/src/features/moneylog/components/LogsSummary/__tests__/SpendingPanel.test.tsx
+++ b/src/features/moneylog/components/LogsSummary/__tests__/SpendingPanel.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach } from "vite-plus/test";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import "@/utils/configuredDayjs";
+import SpendingPanel from "@/features/moneylog/components/LogsSummary/SpendingPanel";
+import type { Group, LogPost } from "@/types/user";
+
+// Noon-UTC timestamps so day bucketing is stable regardless of the runner's tz.
+const JAN = (day: number) => 1705320000 + (day - 15) * 86400; // Jan 15 12:00 UTC
+const group = {
+  id: "g1",
+  title: "Test Group",
+  start: { seconds: JAN(15) },
+  end: { seconds: JAN(19) },
+} as unknown as Group;
+
+const makePost = (amount: number, day: number, currency = "CAD", author = "u1"): LogPost =>
+  ({
+    id: `p-${currency}-${day}-${amount}`,
+    author: { id: author },
+    authorName: author,
+    currency,
+    amount,
+    postDate: { seconds: JAN(day) },
+    content: "x",
+    groupId: "g1",
+  }) as unknown as LogPost;
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("SpendingPanel", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  const gridText = () => container.querySelector(".SpendingInsights__grid")?.textContent ?? "";
+  const clickButton = (label: string) =>
+    act(() => {
+      const btn = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent === label,
+      );
+      btn!.click();
+    });
+
+  it("shows an empty state when there is no spending", () => {
+    act(() => root.render(<SpendingPanel scope="mine" user={{}} logPosts={[]} group={group} />));
+    expect(container.querySelector(".SpendingPanel__empty")).not.toBeNull();
+    expect(container.textContent).toContain("No spending was logged");
+  });
+
+  it("phrases group insights as 'the group', not 'this user'", () => {
+    act(() =>
+      root.render(
+        <SpendingPanel scope="group" user={{}} logPosts={[makePost(100, 16)]} group={group} />,
+      ),
+    );
+    const text = gridText();
+    expect(text).toContain("the group's average");
+    expect(text).toContain("The group logged");
+    expect(text).not.toContain("This user");
+    expect(text).not.toContain("You logged");
+  });
+
+  it("phrases my insights in the second person", () => {
+    act(() =>
+      root.render(
+        <SpendingPanel scope="mine" user={{}} logPosts={[makePost(100, 16)]} group={group} />,
+      ),
+    );
+    const text = gridText();
+    expect(text).toContain("your average");
+    expect(text).toContain("You logged");
+    expect(text).not.toContain("the group");
+  });
+
+  it("shows only the active currency's cards and switches with the selector", () => {
+    // CAD total 300 (highest → default active), USD total 100
+    const logPosts = [makePost(100, 16, "CAD"), makePost(200, 17, "CAD"), makePost(100, 16, "USD")];
+    act(() =>
+      root.render(<SpendingPanel scope="mine" user={{}} logPosts={logPosts} group={group} />),
+    );
+
+    // Default: highest-total currency (CAD) only
+    expect(gridText()).toContain("CAD");
+    expect(gridText()).not.toContain("USD");
+
+    // A currency selector is present for multi-currency groups
+    const currencyButtons = Array.from(container.querySelectorAll("button")).map(
+      (b) => b.textContent,
+    );
+    expect(currencyButtons).toContain("CAD");
+    expect(currencyButtons).toContain("USD");
+
+    // Switching currency swaps which cards' figures are shown
+    clickButton("USD");
+    expect(gridText()).toContain("USD");
+    expect(gridText()).not.toContain("CAD");
+  });
+
+  it("omits the currency selector when there is a single currency", () => {
+    act(() =>
+      root.render(
+        <SpendingPanel
+          scope="mine"
+          user={{}}
+          logPosts={[makePost(100, 16), makePost(50, 17)]}
+          group={group}
+        />,
+      ),
+    );
+    const labels = Array.from(container.querySelectorAll("button")).map((b) => b.textContent);
+    // mode toggle only — no currency chips
+    expect(labels).toContain("bars");
+    expect(labels).not.toContain("CAD");
+  });
+});

--- a/src/features/moneylog/components/LogsSummary/__tests__/spendingSeries.test.ts
+++ b/src/features/moneylog/components/LogsSummary/__tests__/spendingSeries.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vite-plus/test";
+import "@/utils/configuredDayjs";
+import {
+  buildSpendingSeries,
+  autoGranularity,
+} from "@/features/moneylog/components/LogsSummary/spendingSeries";
+import type { Group, LogPost } from "@/types/user";
+import type { FullUserData } from "@/hooks/useGetGroupUsers";
+
+// Noon-UTC timestamps so day bucketing is stable regardless of the runner's timezone.
+// 2024-01-15 is a Monday.
+const JAN = (day: number) => 1705320000 + (day - 15) * 86400; // Jan 15 12:00 UTC = 1705320000
+
+const shortGroup = {
+  id: "g1",
+  start: { seconds: JAN(15), toDate: () => new Date(JAN(15) * 1000) }, // Mon Jan 15
+  end: { seconds: JAN(19), toDate: () => new Date(JAN(19) * 1000) }, // Fri Jan 19
+} as unknown as Group;
+
+const makePost = (amount: number, day: number, currency = "CAD", id?: string): LogPost =>
+  ({
+    id: id ?? `post-${currency}-${day}-${amount}`,
+    author: { id: "user1" },
+    authorName: "Alice",
+    currency,
+    amount,
+    postDate: { seconds: JAN(day), toDate: () => new Date(JAN(day) * 1000) },
+    content: "",
+    groupId: "g1",
+    createdAt: { seconds: JAN(day), toDate: () => new Date(JAN(day) * 1000) },
+  }) as unknown as LogPost;
+
+const at = (currency: string, day: number, series: ReturnType<typeof buildSpendingSeries>) =>
+  series.series
+    .get(currency as never)!
+    .find((p) => p.key === `2024-01-${String(day).padStart(2, "0")}`)!;
+
+describe("buildSpendingSeries — dense day buckets", () => {
+  it("zero-fills every day across the group period", () => {
+    const series = buildSpendingSeries([makePost(100, 16), makePost(40, 18)], shortGroup, {
+      granularity: "day",
+    });
+    const cad = series.series.get("CAD")!;
+    // Jan 15,16,17,18,19 => 5 buckets
+    expect(cad.map((p) => p.key)).toEqual([
+      "2024-01-15",
+      "2024-01-16",
+      "2024-01-17",
+      "2024-01-18",
+      "2024-01-19",
+    ]);
+    expect(at("CAD", 15, series).amount).toBe(0);
+    expect(at("CAD", 16, series).amount).toBe(100);
+    expect(at("CAD", 17, series).amount).toBe(0);
+    expect(at("CAD", 18, series).amount).toBe(40);
+  });
+
+  it("attaches the contributing posts to their bucket", () => {
+    const series = buildSpendingSeries([makePost(100, 16, "CAD", "p-a")], shortGroup);
+    expect(at("CAD", 16, series).posts.map((p) => p.id)).toEqual(["p-a"]);
+    expect(at("CAD", 15, series).posts).toEqual([]);
+  });
+});
+
+describe("buildSpendingSeries — currencies", () => {
+  it("keeps currencies separate and sorts them by total descending", () => {
+    const series = buildSpendingSeries(
+      [makePost(100, 16, "CAD"), makePost(50, 17, "CAD"), makePost(500, 16, "USD")],
+      shortGroup,
+    );
+    expect(series.currencies).toEqual(["USD", "CAD"]); // USD total 500 > CAD 150
+    expect(series.totals.get("CAD")).toBe(150);
+    expect(series.totals.get("USD")).toBe(500);
+    expect(at("USD", 16, series).amount).toBe(500);
+    expect(at("CAD", 16, series).amount).toBe(100);
+  });
+
+  it("returns empty currencies/series when there are no posts", () => {
+    const series = buildSpendingSeries([], shortGroup);
+    expect(series.currencies).toEqual([]);
+    expect(series.series.size).toBe(0);
+  });
+});
+
+describe("buildSpendingSeries — cumulative", () => {
+  it("accumulates and ends at the currency total", () => {
+    const series = buildSpendingSeries([makePost(100, 16), makePost(40, 18)], shortGroup);
+    const cad = series.series.get("CAD")!;
+    expect(cad.map((p) => p.cumulative)).toEqual([0, 100, 100, 140, 140]);
+    expect(cad[cad.length - 1].cumulative).toBe(series.totals.get("CAD"));
+  });
+});
+
+describe("buildSpendingSeries — pinned post exclusion", () => {
+  it("omits the user's pinned post from totals and buckets", () => {
+    const user = {
+      pinnedPosts: { g1: { pinnedPost: "pinned" } },
+    } as unknown as Partial<FullUserData>;
+    const series = buildSpendingSeries(
+      [makePost(100, 16, "CAD", "pinned"), makePost(40, 18, "CAD", "normal")],
+      shortGroup,
+      { user },
+    );
+    expect(series.totals.get("CAD")).toBe(40);
+    expect(at("CAD", 16, series).amount).toBe(0);
+    expect(at("CAD", 18, series).amount).toBe(40);
+  });
+});
+
+describe("buildSpendingSeries — week bucketing", () => {
+  it("collapses same-week posts into one Monday-anchored bucket", () => {
+    const series = buildSpendingSeries([makePost(100, 16), makePost(40, 18)], shortGroup, {
+      granularity: "week",
+    });
+    const cad = series.series.get("CAD")!;
+    // Jan 15 is Monday; Jan 16 & 18 fall in that single week
+    expect(cad).toHaveLength(1);
+    expect(cad[0].key).toBe("2024-01-15");
+    expect(cad[0].amount).toBe(140);
+    expect(cad[0].label).toContain("wk of");
+  });
+});
+
+describe("autoGranularity", () => {
+  it("uses days for short groups and weeks for long ones", () => {
+    expect(autoGranularity(shortGroup)).toBe("day");
+    const longGroup = {
+      start: { seconds: JAN(15) },
+      end: { seconds: JAN(15) + 60 * 86400 },
+    } as unknown as Group;
+    expect(autoGranularity(longGroup)).toBe("week");
+  });
+});

--- a/src/features/moneylog/components/LogsSummary/spendingSeries.ts
+++ b/src/features/moneylog/components/LogsSummary/spendingSeries.ts
@@ -1,0 +1,150 @@
+import dayjs from "@/utils/configuredDayjs";
+import { Currency, Group, LogPost } from "@/types/user";
+import { FullUserData } from "@/hooks/useGetGroupUsers";
+
+export type Granularity = "day" | "week";
+
+export type SpendingPoint = {
+  key: string; // bucket key, YYYY-MM-DD (day, or that week's Monday)
+  date: dayjs.Dayjs; // bucket start
+  label: string; // short human label for the axis / tooltip
+  amount: number; // spend in this bucket for the currency
+  cumulative: number; // running total up to and including this bucket
+  posts: LogPost[]; // posts contributing to this bucket for the currency
+};
+
+export type SpendingSeries = {
+  granularity: Granularity;
+  currencies: Currency[]; // present currencies, highest total first
+  totals: Map<Currency, number>;
+  series: Map<Currency, SpendingPoint[]>; // dense (zero-filled) per currency
+};
+
+type BuildOptions = {
+  user?: Partial<FullUserData>;
+  granularity?: Granularity;
+};
+
+// Long groups get weekly buckets so the axis doesn't turn into a hairline forest.
+const WEEK_GRANULARITY_THRESHOLD_DAYS = 35;
+
+export const autoGranularity = (group: Group): Granularity => {
+  const start = dayjs(group.start.seconds * 1000);
+  const end = dayjs(group.end.seconds * 1000);
+  return end.diff(start, "day") + 1 > WEEK_GRANULARITY_THRESHOLD_DAYS ? "week" : "day";
+};
+
+// Monday-based week start, matching the week keys used in SpendingInsights.
+const mondayOf = (d: dayjs.Dayjs): dayjs.Dayjs => {
+  const dayOfWeek = d.day() === 0 ? 6 : d.day() - 1; // Sun=0 -> 6, others shift down
+  return d.subtract(dayOfWeek, "day").startOf("day");
+};
+
+const bucketDateOf = (d: dayjs.Dayjs, granularity: Granularity): dayjs.Dayjs =>
+  granularity === "week" ? mondayOf(d) : d.startOf("day");
+
+const keyOf = (d: dayjs.Dayjs, granularity: Granularity): string =>
+  bucketDateOf(d, granularity).format("YYYY-MM-DD");
+
+const labelOf = (d: dayjs.Dayjs, granularity: Granularity): string =>
+  granularity === "week" ? `wk of ${d.format("D MMM")}` : d.format("D MMM");
+
+/**
+ * Bucket a set of posts into a dense, zero-filled time series per currency.
+ *
+ * Mirrors SpendingInsights' aggregation so the graph agrees with the textual
+ * totals: excludes the user's pinned post and posts outside [group.start, group.end]
+ * (browser-tz, day-granular), and buckets each post by its cached postTimezone when
+ * available (else browser tz).
+ */
+export const buildSpendingSeries = (
+  logPosts: LogPost[],
+  group: Group,
+  { user, granularity = "day" }: BuildOptions = {},
+): SpendingSeries => {
+  const pinnedPostId = user?.pinnedPosts?.[group.id]?.pinnedPost;
+  const groupStart = dayjs(group.start.seconds * 1000);
+  const groupEnd = dayjs(group.end.seconds * 1000);
+
+  const hasCachedAnalytics = group.analytics?.isCalculated;
+  const postsMetadata = group.analytics?.posts;
+
+  const legitimatePosts = logPosts.filter((log) => {
+    const postDate = dayjs(log.postDate.seconds * 1000);
+    const isNotPinned = pinnedPostId ? log.id !== pinnedPostId : true;
+    return (
+      isNotPinned && !postDate.isAfter(groupEnd, "day") && !postDate.isBefore(groupStart, "day")
+    );
+  });
+
+  // Aggregate amount + posts per (currency, bucket key).
+  type Bucket = { date: dayjs.Dayjs; amount: number; posts: LogPost[] };
+  const perCurrency = new Map<Currency, Map<string, Bucket>>();
+  const totals = new Map<Currency, number>();
+
+  legitimatePosts.forEach((log) => {
+    const tz =
+      hasCachedAnalytics && postsMetadata?.[log.id]?.postTimezone
+        ? postsMetadata[log.id].postTimezone
+        : undefined;
+    const postDate = tz
+      ? dayjs(log.postDate.seconds * 1000).tz(tz)
+      : dayjs(log.postDate.seconds * 1000);
+    const key = keyOf(postDate, granularity);
+    const currency = log.currency;
+    const amount = Number(log.amount) || 0;
+
+    if (!perCurrency.has(currency)) perCurrency.set(currency, new Map());
+    const buckets = perCurrency.get(currency)!;
+    if (!buckets.has(key)) buckets.set(key, { date: dayjs(key), amount: 0, posts: [] });
+    const bucket = buckets.get(key)!;
+    bucket.amount += amount;
+    bucket.posts.push(log);
+
+    totals.set(currency, (totals.get(currency) ?? 0) + amount);
+  });
+
+  const currencies = [...totals.keys()].sort((a, b) => (totals.get(b) ?? 0) - (totals.get(a) ?? 0));
+
+  if (currencies.length === 0) {
+    return { granularity, currencies, totals, series: new Map() };
+  }
+
+  // Continuous axis spanning the group period and every populated bucket.
+  const candidateDates: dayjs.Dayjs[] = [
+    bucketDateOf(groupStart, granularity),
+    bucketDateOf(groupEnd, granularity),
+  ];
+  perCurrency.forEach((buckets) => buckets.forEach((b) => candidateDates.push(b.date)));
+
+  let cursor = candidateDates.reduce((min, d) => (d.isBefore(min) ? d : min), candidateDates[0]);
+  const axisEnd = candidateDates.reduce((max, d) => (d.isAfter(max) ? d : max), candidateDates[0]);
+
+  const axis: { key: string; date: dayjs.Dayjs }[] = [];
+  while (!cursor.isAfter(axisEnd, "day")) {
+    axis.push({ key: cursor.format("YYYY-MM-DD"), date: cursor });
+    cursor = granularity === "week" ? cursor.add(7, "day") : cursor.add(1, "day");
+  }
+
+  const series = new Map<Currency, SpendingPoint[]>();
+  currencies.forEach((currency) => {
+    const buckets = perCurrency.get(currency) ?? new Map<string, Bucket>();
+    let cumulative = 0;
+    const points = axis.map(({ key, date }) => {
+      const bucket = buckets.get(key);
+      const amount = bucket?.amount ?? 0;
+      cumulative += amount;
+      return {
+        key,
+        date,
+        label: labelOf(date, granularity),
+        amount,
+        cumulative,
+        posts: bucket?.posts ?? [],
+      };
+    });
+    series.set(currency, points);
+  });
+
+  return { granularity, currencies, totals, series };
+};

--- a/src/features/moneylog/components/LogsSummary/styles.scss
+++ b/src/features/moneylog/components/LogsSummary/styles.scss
@@ -33,7 +33,7 @@
     border-radius: 5px;
     color: #fff;
     background-color: var(--c-black);
-    font-size: 0.9em;
+    font-size: 0.7em;
     margin: 1em 0;
     padding: 1em;
   }
@@ -78,7 +78,7 @@
     font-size: 0.85em;
     cursor: pointer;
     padding: 0.35em 1.1em;
-    border: 2px 2px 2px 0 solid var(--c-black);
+    border: 2px solid var(--c-black);
     border-bottom: none;
     border-radius: 6px 6px 0 0;
     background: var(--c-black);

--- a/src/features/moneylog/components/LogsSummary/styles.scss
+++ b/src/features/moneylog/components/LogsSummary/styles.scss
@@ -79,7 +79,6 @@
     cursor: pointer;
     padding: 0.35em 1.1em;
     border: 2px solid var(--c-black);
-    border-bottom: none;
     border-radius: 6px 6px 0 0;
     background: var(--c-white);
     color: var(--c-black);
@@ -88,6 +87,7 @@
     &--active {
       background: var(--c-white);
       color: var(--c-black);
+      border-bottom: none;
       top: 0;
       z-index: 2;
     }

--- a/src/features/moneylog/components/LogsSummary/styles.scss
+++ b/src/features/moneylog/components/LogsSummary/styles.scss
@@ -81,8 +81,8 @@
     border: 2px solid var(--c-black);
     border-bottom: none;
     border-radius: 6px 6px 0 0;
-    background: var(--c-black);
-    color: var(--c-white);
+    background: var(--c-white);
+    color: var(--c-black);
     position: relative;
 
     &--active {

--- a/src/features/moneylog/components/LogsSummary/styles.scss
+++ b/src/features/moneylog/components/LogsSummary/styles.scss
@@ -78,13 +78,12 @@
     font-size: 0.85em;
     cursor: pointer;
     padding: 0.35em 1.1em;
-    border: 2px solid var(--c-black);
+    border: 2px 2px 2px 0 solid var(--c-black);
     border-bottom: none;
     border-radius: 6px 6px 0 0;
     background: var(--c-black);
     color: var(--c-white);
     position: relative;
-    top: 2px; // inactive tabs sit slightly lower / behind
 
     &--active {
       background: var(--c-white);

--- a/src/features/moneylog/components/LogsSummary/styles.scss
+++ b/src/features/moneylog/components/LogsSummary/styles.scss
@@ -44,6 +44,136 @@
   }
 }
 
+// Segmented control (tabs, graph-mode toggle, currency chips) built from Buttons.
+.Segmented {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.4em;
+  justify-content: center;
+
+  &--tabs {
+    margin-bottom: 1em;
+  }
+}
+
+.SpendingPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+
+  &__controls {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5em;
+  }
+
+  &__empty {
+    opacity: 0.6;
+    padding: 1.5em 0;
+  }
+
+  &__daydetail {
+    text-align: left;
+    font-size: 0.9em;
+  }
+}
+
+.SpendingChart {
+  position: relative;
+  width: 100%;
+
+  &__svg {
+    width: 100%;
+    height: auto;
+    display: block;
+    overflow: visible;
+  }
+
+  &__bar {
+    fill: var(--c-black);
+
+    &--hover {
+      fill: var(--c-black);
+    }
+
+    &--dim {
+      opacity: 0.35;
+    }
+  }
+
+  &__line {
+    fill: none;
+    stroke: var(--c-black);
+    stroke-width: 2;
+    stroke-linejoin: round;
+    stroke-linecap: round;
+  }
+
+  &__area {
+    fill: var(--c-black);
+    opacity: 0.07;
+  }
+
+  &__dot {
+    fill: var(--c-black);
+    stroke: var(--c-white);
+    stroke-width: 2;
+  }
+
+  &__axis {
+    stroke: var(--c-black);
+    stroke-width: 1.5;
+  }
+
+  &__grid {
+    stroke: var(--c-black);
+    opacity: 0.15;
+    stroke-dasharray: 2 3;
+  }
+
+  &__ytick,
+  &__xtick {
+    fill: var(--c-black);
+    opacity: 0.6;
+    font-size: 11px;
+    font-family: inherit;
+  }
+
+  &__hit {
+    fill: transparent;
+    cursor: pointer;
+    outline: none;
+
+    &:focus-visible {
+      fill: var(--c-black);
+      opacity: 0.08;
+    }
+  }
+
+  &__tooltip {
+    position: absolute;
+    transform: translate(-50%, -130%);
+    pointer-events: none;
+    background: var(--c-black);
+    color: var(--c-white);
+    border-radius: 4px;
+    padding: 0.35em 0.55em;
+    font-size: 0.72em;
+    white-space: nowrap;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.1em;
+    z-index: 5;
+
+    &__meta {
+      opacity: 0.7;
+    }
+  }
+}
+
 .PostPreview {
   display: flex;
   flex-direction: column;
@@ -95,9 +225,9 @@
     align-items: center;
     gap: 0.75em;
 
-    &__emoji {
-      font-size: 1.6em;
-      line-height: 1;
+    &__icon {
+      display: inline-flex;
+      align-items: center;
       flex-shrink: 0;
     }
 
@@ -132,8 +262,9 @@
     border-radius: 6px;
     background: #fafafa;
 
-    &__emoji {
-      font-size: 1.4em;
+    &__icon {
+      display: inline-flex;
+      align-items: center;
       flex-shrink: 0;
     }
 

--- a/src/features/moneylog/components/LogsSummary/styles.scss
+++ b/src/features/moneylog/components/LogsSummary/styles.scss
@@ -8,6 +8,9 @@
   width: 60vw;
   height: 100%;
   overflow-y: auto;
+  overflow-x: hidden;
+  min-width: 0;
+  box-sizing: border-box;
 
   @media (max-width: constants.$breakpoint-md) {
     display: flex;
@@ -36,11 +39,73 @@
   }
 
   &__ScrollList {
-    display: inline-flex;
+    display: flex;
     flex-wrap: nowrap;
-    overflow-y: auto;
+    overflow-x: auto;
+    overflow-y: hidden;
     gap: 0.8em;
     width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+    padding-bottom: 0.4em;
+  }
+
+  // Filing-folder tabbed spending section.
+  &__spending {
+    width: 100%;
+    max-width: 100%;
+    text-align: left;
+    box-sizing: border-box;
+
+    &__body {
+      min-width: 0;
+    }
+  }
+}
+
+// Filing-folder tabs that peek up out of the top border of the .Window below them.
+.Tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3em;
+  padding-left: 1em;
+  margin-bottom: -2px; // overlap the box's 2px top border so the active tab merges in
+  position: relative;
+  z-index: 1;
+
+  &__tab {
+    font: inherit;
+    font-size: 0.85em;
+    cursor: pointer;
+    padding: 0.35em 1.1em;
+    border: 2px solid var(--c-black);
+    border-bottom: none;
+    border-radius: 6px 6px 0 0;
+    background: var(--c-black);
+    color: var(--c-white);
+    position: relative;
+    top: 2px; // inactive tabs sit slightly lower / behind
+
+    &--active {
+      background: var(--c-white);
+      color: var(--c-black);
+      top: 0;
+      z-index: 2;
+    }
+  }
+}
+
+// Insight cards laid out in a responsive grid (the posts insight stays full-width).
+.SpendingInsights__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.8em;
+  margin: 1em 0;
+
+  .LogsSummary__bubble {
+    margin: 0;
+    height: 100%;
+    box-sizing: border-box;
   }
 }
 
@@ -60,6 +125,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.5em;
+  min-width: 0;
 
   &__controls {
     display: flex;
@@ -88,7 +154,7 @@
     width: 100%;
     height: auto;
     display: block;
-    overflow: visible;
+    overflow: hidden;
   }
 
   &__bar {

--- a/src/hooks/useAchievements.ts
+++ b/src/hooks/useAchievements.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { collection, doc, getDocs, setDoc, serverTimestamp } from "firebase/firestore";
 import { db } from "@/config/firebase-config";
 import { Currency, LogPost } from "@/types/user";
+import { IconType } from "@/components/Icon";
 
 export type AchievementType = "top_spender" | "lowest_spender" | "time_traveller";
 
@@ -16,20 +17,20 @@ export type Achievement = {
 
 export const ACHIEVEMENT_META: Record<
   AchievementType,
-  { emoji: string; title: string; description: (currency?: string) => string }
+  { icon: IconType; title: string; description: (currency?: string) => string }
 > = {
   top_spender: {
-    emoji: "🏆",
+    icon: "dollar",
     title: "Top Spender",
     description: (currency) => `Highest total ${currency} spending in the group`,
   },
   lowest_spender: {
-    emoji: "💡",
+    icon: "dollar",
     title: "Lowest Spender",
     description: (currency) => `Lowest total ${currency} spending in the group`,
   },
   time_traveller: {
-    emoji: "🌍",
+    icon: "location",
     title: "Time Traveller",
     description: () => "Logged entries from multiple timezones in one session",
   },

--- a/src/index.css
+++ b/src/index.css
@@ -13,7 +13,9 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-div, nav, section {
+div,
+nav,
+section {
   box-sizing: border-box;
 }
 
@@ -25,15 +27,6 @@ a {
 a:hover {
   /*color: #fff;*/
   /*animation: chroab 400ms ease-in-out both;*/
-}
-
-@keyframes chroab {
-  0% {
-    text-shadow: 0 0 #d00031, 0 0 #2b8dfd, 0 6px 0 transparent, 8px 0 0 transparent
-  }
-  100% {
-    text-shadow: 0.06ex 0 #d00031, -0.06ex 0 #2b8dfd, 0 0.14ex 0 rgba(0,0,0,.8), 0.12ex 0 0 rgba(0,0,0,.8)
-  }
 }
 
 body {
@@ -59,23 +52,7 @@ button {
   cursor: pointer;
   transition: border-color 0.25s;
 }
-button:hover {
-  border-color: #646cff;
-}
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }

--- a/src/pages/me/index.tsx
+++ b/src/pages/me/index.tsx
@@ -13,6 +13,7 @@ import { useGetAchievements, ACHIEVEMENT_META } from "@/hooks/useAchievements";
 
 import Button from "@/components/Button";
 import ControlledInput from "@/components/ControlledInput";
+import Icon from "@/components/Icon";
 
 import "./me.scss";
 import "@/features/moneylog/components/LogsSummary/styles.scss";
@@ -156,12 +157,8 @@ export const UserSettings = () => {
               const meta = ACHIEVEMENT_META[achievement.type];
               return (
                 <div key={achievement.id} className="AchievementsList__item">
-                  <span
-                    className="AchievementsList__item__emoji"
-                    role="img"
-                    aria-label={meta.title}
-                  >
-                    {meta.emoji}
+                  <span className="AchievementsList__item__icon" aria-hidden="true">
+                    <Icon type={meta.icon} />
                   </span>
                   <div className="AchievementsList__item__text">
                     <strong>


### PR DESCRIPTION
### What changed

New interactive graph (custom inline SVG, no dependency):
- spendingSeries.ts — a tested pure helper that buckets posts into a dense, zero-filled per-currency day/week time series with cumulative totals, mirroring SpendingInsights' filtering and timezone handling so the graph agrees with the textual totals. 8 unit tests.
- SpendingChart.tsx — the SVG chart with bars and cumulative-line modes, hover tooltips, click-to-select, a recessive monochrome axis, and accessibility (role="img" + focusable per-bucket hit targets). Built per the dataviz mark specs (4px rounded bar tops on the baseline, 2px line, thin recessive gridlines). 3 render/interaction smoke tests.
- SpendingPanel.tsx — wraps it all: the [ bars | cumulative ] toggle, a currency selector (only when a group has >1 currency), the chart, clicked-bar post previews, and the existing textual insights below.

Layout — tabs: LogsSummary.tsx now has one spending Window with [ My spending | Group spending ] tabs (plus the admin "view a member" tab, preserved and routed through the same panel). Hot posts stays at the bottom, unchanged.

Emoji purge (everywhere): removed 💰 💸 📊 📈 ⚠️ 🔥 😅 from the summary, and swapped the achievement badges (🏆 💡 🌍) to the app's Icon set (dollar/location) — updating ACHIEVEMENT_META, both AchievementsBanner and the profile-page achievements list, and the __emoji→__icon SCSS. Also removed a stray console.log in SpendingInsights.

Reuse: Button isSelected for all segmented controls, configuredDayjs, the extracted PostPreview, and the existing SpendingInsights.* insight components (kept, emoji-free)