### PR TITLE
feat: prompt to refresh when a long-open tab has a stale build

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -17,6 +17,20 @@
         "source": "**",
         "destination": "/index.html"
       }
+    ],
+    "headers": [
+      {
+        "source": "/index.html",
+        "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
+      },
+      {
+        "source": "/version.json",
+        "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
+      },
+      {
+        "source": "**/assets/**",
+        "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
+      }
     ]
   },
   "emulators": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vp dev",
-    "build": "vp build",
+    "build": "vp build && node scripts/write-version.mjs",
     "lint": "vp lint .",
     "preview": "vp preview",
     "seed-emulator": "npx tsx scripts/seed-emulator.ts",

--- a/scripts/write-version.mjs
+++ b/scripts/write-version.mjs
@@ -1,0 +1,28 @@
+// Emits dist/version.json after the build so a long-open client tab can detect a
+// newer deploy (see src/hooks/useAppVersionRefresh.ts). buildId comes from the git
+// short SHA — it changes on every deploy of new code even when package.json's
+// version isn't bumped; falls back to a timestamp when git isn't available.
+import { execSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const distDir = resolve(process.cwd(), "dist");
+
+let buildId;
+try {
+  buildId = execSync("git rev-parse --short HEAD", { stdio: ["ignore", "pipe", "ignore"] })
+    .toString()
+    .trim();
+} catch {
+  buildId = String(Date.now());
+}
+
+const payload = {
+  buildId,
+  version: process.env.npm_package_version ?? "unknown",
+  builtAt: new Date().toISOString(),
+};
+
+mkdirSync(distDir, { recursive: true });
+writeFileSync(resolve(distDir, "version.json"), JSON.stringify(payload, null, 2));
+console.log(`📝 wrote dist/version.json (${payload.buildId})`);

--- a/src/App.scss
+++ b/src/App.scss
@@ -194,6 +194,38 @@ html {
   }
 }
 
+.UpdateBanner {
+  position: fixed;
+  bottom: 1em;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  display: inline-flex;
+  align-items: center;
+  grid-gap: 0.75em;
+  max-width: calc(100vw - 2em);
+  box-sizing: border-box;
+  padding: 0.5em 0.5em 0.5em 1em;
+  background-color: var(--c-white);
+  border: 2px solid var(--c-black);
+  border-radius: 4px;
+  font-size: 0.85em;
+
+  &__text {
+    white-space: nowrap;
+  }
+
+  &__dismiss {
+    border: none;
+    background: none;
+    cursor: pointer;
+    font-size: 1.2em;
+    line-height: 1;
+    padding: 0 0.25em;
+    color: var(--c-black);
+  }
+}
+
 .IconText {
   display: inline-flex;
   grid-gap: 0.2em;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useEffect } from "react";
+import { PropsWithChildren, useEffect, useState } from "react";
 import {
   BrowserRouter as Router,
   Route,
@@ -12,7 +12,9 @@ import { auth } from "@/config/firebase-config";
 import Layout from "@/features/layout/Layout";
 import GlobalErrorHandler from "@/utils/errorHandler";
 import { useToastContext } from "@/hooks/useToastContext";
+import { useAppVersionRefresh } from "@/hooks/useAppVersionRefresh";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import UpdateBanner from "@/components/UpdateBanner";
 
 import { Auth } from "@/pages/auth";
 import { Home } from "@/pages/home";
@@ -54,6 +56,8 @@ export const CheckAuth = ({
 
 const App = () => {
   const { showToast } = useToastContext();
+  const { updateAvailable, refresh } = useAppVersionRefresh();
+  const [updateDismissed, setUpdateDismissed] = useState(false);
 
   useEffect(() => {
     GlobalErrorHandler.getInstance().initialize(showToast);
@@ -61,6 +65,9 @@ const App = () => {
 
   return (
     <Router>
+      {updateAvailable && !updateDismissed && (
+        <UpdateBanner onRefresh={refresh} onDismiss={() => setUpdateDismissed(true)} />
+      )}
       <Layout>
         <ErrorBoundary>
           <Routes>

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -1,0 +1,27 @@
+import Button from "./Button";
+
+interface UpdateBannerProps {
+  onRefresh: () => void;
+  onDismiss: () => void;
+}
+
+// Slim, dismissible "a new version is available" prompt. Shown by App when
+// useAppVersionRefresh detects a newer deploy on a long-idle tab.
+const UpdateBanner = ({ onRefresh, onDismiss }: UpdateBannerProps) => {
+  return (
+    <div className="UpdateBanner" role="alert">
+      <span className="UpdateBanner__text">A new version is available.</span>
+      <Button text="Refresh" size="sm" buttonStyle="primary-border" onClick={onRefresh} />
+      <button
+        type="button"
+        className="UpdateBanner__dismiss"
+        aria-label="Dismiss"
+        onClick={onDismiss}
+      >
+        ×
+      </button>
+    </div>
+  );
+};
+
+export default UpdateBanner;

--- a/src/components/__tests__/UpdateBanner.test.tsx
+++ b/src/components/__tests__/UpdateBanner.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vite-plus/test";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import UpdateBanner from "@/components/UpdateBanner";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("UpdateBanner", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  const clickByText = (text: string) =>
+    act(() => {
+      const btn = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent === text,
+      );
+      btn!.click();
+    });
+
+  it("renders the message and a refresh action", () => {
+    act(() => root.render(<UpdateBanner onRefresh={() => {}} onDismiss={() => {}} />));
+    expect(container.textContent).toContain("A new version is available");
+    const labels = Array.from(container.querySelectorAll("button")).map((b) => b.textContent);
+    expect(labels).toContain("Refresh");
+  });
+
+  it("calls onRefresh when Refresh is clicked", () => {
+    const onRefresh = vi.fn();
+    act(() => root.render(<UpdateBanner onRefresh={onRefresh} onDismiss={() => {}} />));
+    clickByText("Refresh");
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onDismiss when the × is clicked", () => {
+    const onDismiss = vi.fn();
+    act(() => root.render(<UpdateBanner onRefresh={() => {}} onDismiss={onDismiss} />));
+    act(() => {
+      container.querySelector<HTMLButtonElement>(".UpdateBanner__dismiss")!.click();
+    });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/__tests__/useAppVersionRefresh.test.ts
+++ b/src/hooks/__tests__/useAppVersionRefresh.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vite-plus/test";
+import { shouldPromptUpdate } from "@/hooks/useAppVersionRefresh";
+
+const AWAY = 4 * 60 * 60 * 1000;
+
+describe("shouldPromptUpdate", () => {
+  it("is false when the running build id is unknown", () => {
+    expect(shouldPromptUpdate({ bootBuildId: null, fetchedBuildId: "abc", hiddenMs: AWAY })).toBe(
+      false,
+    );
+  });
+
+  it("is false when the fetched build id is unknown", () => {
+    expect(shouldPromptUpdate({ bootBuildId: "abc", fetchedBuildId: null, hiddenMs: AWAY })).toBe(
+      false,
+    );
+  });
+
+  it("is false when the build is unchanged", () => {
+    expect(shouldPromptUpdate({ bootBuildId: "abc", fetchedBuildId: "abc", hiddenMs: AWAY })).toBe(
+      false,
+    );
+  });
+
+  it("is false when a newer build exists but the tab wasn't away long enough", () => {
+    expect(
+      shouldPromptUpdate({ bootBuildId: "abc", fetchedBuildId: "def", hiddenMs: AWAY - 1 }),
+    ).toBe(false);
+  });
+
+  it("is true when a newer build exists and the tab was away past the threshold", () => {
+    expect(shouldPromptUpdate({ bootBuildId: "abc", fetchedBuildId: "def", hiddenMs: AWAY })).toBe(
+      true,
+    );
+  });
+
+  it("respects a custom awayMs threshold", () => {
+    expect(
+      shouldPromptUpdate({ bootBuildId: "abc", fetchedBuildId: "def", hiddenMs: 60, awayMs: 100 }),
+    ).toBe(false);
+    expect(
+      shouldPromptUpdate({ bootBuildId: "abc", fetchedBuildId: "def", hiddenMs: 100, awayMs: 100 }),
+    ).toBe(true);
+  });
+});

--- a/src/hooks/__tests__/useAppVersionRefresh.wiring.test.tsx
+++ b/src/hooks/__tests__/useAppVersionRefresh.wiring.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vite-plus/test";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppVersionRefresh } from "@/hooks/useAppVersionRefresh";
+
+const AWAY = 4 * 60 * 60 * 1000;
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let latest: { updateAvailable: boolean } = { updateAvailable: false };
+const Probe = () => {
+  latest = useAppVersionRefresh();
+  return null;
+};
+
+// Controllable stand-ins for the browser environment.
+let servedBuildId = "old";
+let now = 1_000;
+let hidden = false;
+
+const setHidden = (value: boolean) => {
+  hidden = value;
+  document.dispatchEvent(new Event("visibilitychange"));
+};
+
+describe("useAppVersionRefresh wiring", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    servedBuildId = "old";
+    now = 1_000;
+    hidden = false;
+    latest = { updateAvailable: false };
+
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => hidden });
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ buildId: servedBuildId }),
+    })) as unknown as typeof fetch;
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+    delete (document as unknown as { hidden?: boolean }).hidden;
+  });
+
+  const mount = async () => {
+    await act(async () => {
+      root.render(<Probe />);
+    });
+    await act(async () => {}); // flush the boot version fetch
+  };
+
+  it("prompts after returning past the away threshold to a new build", async () => {
+    await mount();
+
+    await act(async () => setHidden(true)); // tab hidden at now=1000
+    now += AWAY + 1; // ...return 4h+ later
+    servedBuildId = "new"; // ...to a new deploy
+    await act(async () => setHidden(false));
+    await act(async () => {}); // flush the version re-fetch
+
+    expect(latest.updateAvailable).toBe(true);
+  });
+
+  it("does not prompt when returning too soon", async () => {
+    await mount();
+
+    await act(async () => setHidden(true));
+    now += AWAY - 1_000; // just under the threshold
+    servedBuildId = "new";
+    await act(async () => setHidden(false));
+    await act(async () => {});
+
+    expect(latest.updateAvailable).toBe(false);
+  });
+
+  it("does not prompt when the build is unchanged", async () => {
+    await mount();
+
+    await act(async () => setHidden(true));
+    now += AWAY + 1;
+    // servedBuildId stays "old"
+    await act(async () => setHidden(false));
+    await act(async () => {});
+
+    expect(latest.updateAvailable).toBe(false);
+  });
+});

--- a/src/hooks/useAppVersionRefresh.ts
+++ b/src/hooks/useAppVersionRefresh.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// How long the tab must have been hidden before a return checks for a new deploy.
+// Tune here (4 hours). Kept generous so a brief step-away never prompts.
+const AWAY_MS = 4 * 60 * 60 * 1000;
+
+const VERSION_URL = "/version.json";
+
+type VersionInfo = { buildId?: string };
+
+// Pure decision: prompt only when we know the build we booted with, a newer build
+// is deployed, and the tab has been away long enough to be worth interrupting.
+export const shouldPromptUpdate = ({
+  bootBuildId,
+  fetchedBuildId,
+  hiddenMs,
+  awayMs = AWAY_MS,
+}: {
+  bootBuildId: string | null;
+  fetchedBuildId: string | null | undefined;
+  hiddenMs: number;
+  awayMs?: number;
+}): boolean => {
+  if (!bootBuildId || !fetchedBuildId) return false;
+  if (hiddenMs < awayMs) return false;
+  return fetchedBuildId !== bootBuildId;
+};
+
+const fetchBuildId = async (): Promise<string | null> => {
+  try {
+    const res = await fetch(`${VERSION_URL}?ts=${Date.now()}`, { cache: "no-store" });
+    if (!res.ok) return null;
+    const data = (await res.json()) as VersionInfo;
+    return data.buildId ?? null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Surfaces a prompt when the user returns to a long-hidden tab (>= AWAY_MS) and a
+ * newer app build has been deployed. Never reloads on its own — the UI decides.
+ */
+export const useAppVersionRefresh = () => {
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+  const bootBuildId = useRef<string | null>(null);
+  const hiddenAt = useRef<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    // Record the build this tab is running. If it can't be fetched (dev/offline),
+    // the feature simply stays dormant.
+    void fetchBuildId().then((id) => {
+      if (!cancelled) bootBuildId.current = id;
+    });
+
+    const onVisibilityChange = () => {
+      if (document.hidden) {
+        hiddenAt.current = Date.now();
+        return;
+      }
+
+      const hiddenMs = hiddenAt.current ? Date.now() - hiddenAt.current : 0;
+      hiddenAt.current = null;
+      if (!bootBuildId.current || hiddenMs < AWAY_MS) return;
+
+      void fetchBuildId().then((fetchedBuildId) => {
+        if (cancelled) return;
+        if (shouldPromptUpdate({ bootBuildId: bootBuildId.current, fetchedBuildId, hiddenMs })) {
+          setUpdateAvailable(true);
+        }
+      });
+    };
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      cancelled = true;
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, []);
+
+  const refresh = useCallback(() => {
+    window.location.reload();
+  }, []);
+
+  return { updateAvailable, refresh };
+};


### PR DESCRIPTION
Long-open tabs keep running an old bundle after a deploy. Detect this on return and surface a dismissible "A new version is available – refresh" banner (never auto-reloads).

- scripts/write-version.mjs: emit dist/version.json { buildId, version, builtAt } after the build (buildId = git short SHA, so it changes every deploy even without a package.json bump). Wired into the build script.
- firebase.json: add cache headers — no-cache for index.html and version.json (so a return/refresh gets the new build), immutable for hashed assets.
- useAppVersionRefresh: on visibilitychange, if the tab was hidden >= 4h and version.json reports a new buildId, flag an update. Pure, tested shouldPromptUpdate helper; no-ops if the fetch fails.
- UpdateBanner: dismissible prompt with a Refresh button, mounted in App (the toast system is text-only/auto-dismiss, so unsuitable).