### PR TITLE
Fix: clear the nav bell reliably when viewing an updated log

### DIFF
--- a/src/features/moneylog/components/Group.tsx
+++ b/src/features/moneylog/components/Group.tsx
@@ -174,7 +174,9 @@ export const Group = ({
       if (viewedUserDocRefId === viewingUserDocRefId) return;
 
       // Only write when there's genuinely a new post to mark as read; idly clicking
-      // back to a member you're caught up on shouldn't touch the database.
+      // back to a member you're caught up on shouldn't touch the database. This also
+      // reads false while our own write is still in flight, so the re-runs triggered by
+      // `members` landing can't queue a duplicate write.
       const viewedMember = members.find((m) => m.id === viewedUserDocRefId);
       if (
         !memberHasUnreadPosts({
@@ -203,7 +205,12 @@ export const Group = ({
     };
 
     updateViewTracking();
-  }, [displayUser?.userId, loggedInUser?.userId, groupId]);
+    // `members` and `userIdToDocRefMap` belong here, not just the ids: useGetGroupUsers
+    // paints from a localStorage cache that omits `lastUpdated`, so an early run sees
+    // every member as "nothing new" and skips the write. Without these deps the effect
+    // never retries once the real snapshot lands, and the bell stays lit for a log the
+    // user already read. Both are identity-stable unless the member set really changed.
+  }, [displayUser?.userId, loggedInUser?.userId, groupId, members, userIdToDocRefMap]);
 
   const handleUserChange = (newUser?: unknown) => {
     if (newUser) {

--- a/src/features/moneylog/components/__tests__/Group.viewTracking.test.tsx
+++ b/src/features/moneylog/components/__tests__/Group.viewTracking.test.tsx
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vite-plus/test";
+import { act, useMemo } from "react";
+import { createRoot, Root } from "react-dom/client";
+
+import type { Group as GroupType } from "@/types/user";
+
+// Mutable fixtures the mocked hooks read from, so a test can swap in a fresh Firestore
+// snapshot mid-render the way useGetGroupUsers does when its listener fires.
+const state = vi.hoisted(() => ({
+  users: [] as Array<Record<string, unknown>>,
+  viewTracking: undefined as unknown,
+  updateViewTrackingFn: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/contexts", () => ({
+  useCurrentUser: () => ({
+    user: { id: "meDoc", userId: "authMe", timezone: "UTC", viewTracking: state.viewTracking },
+  }),
+}));
+vi.mock("@/contexts/TutorialContext", () => ({
+  useTutorial: () => ({
+    showNewEntryTip: false,
+    dismissNewEntryTip: vi.fn(),
+    onNewEntryClicked: vi.fn(),
+  }),
+}));
+vi.mock("@/hooks/useReadTracking", () => ({
+  useReadTracking: () => ({ trackUserAction: vi.fn() }),
+}));
+vi.mock("@/hooks/useUserQuery", () => ({
+  useUserQuery: () => ({ updateViewTrackingFn: state.updateViewTrackingFn }),
+}));
+vi.mock("@/hooks/useGetLogPosts", () => ({
+  useGetLogPosts: () => ({ posts: [], isLoading: false, isSuccess: true, isError: false }),
+}));
+vi.mock("@/hooks/useGetGroupUsers", () => ({
+  useGetGroupUsers: () => {
+    const users = state.users;
+    // Mirrors the real hook: the map is memoized on the users array, so its identity
+    // changes exactly when the member data does.
+    const userIdToDocRefMap = useMemo(
+      () => new Map(users.map((u) => [u.userId as string, u.id as string])),
+      [users],
+    );
+    return { users, isLoading: false, userIdToDocRefMap, error: null };
+  },
+}));
+
+// Stand in for the nav so a test can pick a member without dnd-kit in the way.
+vi.mock("@/features/moneylog/components/LogsMenu", () => ({
+  default: ({
+    logMembers,
+    onChangeUser,
+  }: {
+    logMembers: Array<{ id: string }>;
+    onChangeUser: (u: unknown) => void;
+  }) => (
+    <div>
+      {logMembers.map((m) => (
+        <button key={m.id} data-testid={`view-${m.id}`} onClick={() => onChangeUser(m)}>
+          {m.id}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("@/features/moneylog/components/ActiveLog", () => ({ ActiveLog: () => null }));
+vi.mock("@/features/moneylog/components/LogsSummary/LogsSummary", () => ({ default: () => null }));
+vi.mock("@/components/Modal", () => ({ default: () => null }));
+vi.mock("@/components/TutorialTooltip", () => ({ default: () => null }));
+vi.mock("@/features/layout/components/CopyTextArea", () => ({ default: () => null }));
+vi.mock("@/components/Icon", () => ({
+  default: () => null,
+  IconText: () => null,
+}));
+
+import { Group } from "@/features/moneylog/components/Group";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const GROUP_ID = "g1";
+const DAY = 86_400_000;
+const stamp = (date: Date) => ({
+  toDate: () => date,
+  seconds: Math.floor(date.getTime() / 1000),
+  nanoseconds: 0,
+});
+
+// An active group: started yesterday, ends well beyond the "ending soon" warning window.
+const group = {
+  start: stamp(new Date(Date.now() - DAY)),
+  end: stamp(new Date(Date.now() + 30 * DAY)),
+  members: [{ id: "meDoc" }, { id: "m2Doc" }],
+  max_participants: 5,
+} as unknown as GroupType;
+
+const me = { id: "meDoc", userId: "authMe", displayName: "Me" };
+// The shape useGetGroupUsers puts in state on a localStorage cache hit: CacheableUserData
+// omits lastUpdated, so nothing looks unread yet.
+const cachedMember2 = { id: "m2Doc", userId: "auth2", displayName: "Two" };
+// The shape once the real Firestore snapshot lands.
+const freshMember2 = { ...cachedMember2, lastUpdated: { [GROUP_ID]: { seconds: 1000 } } };
+
+describe("Group — view tracking writes", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const render = () =>
+    act(() => {
+      root.render(<Group group={group} groupId={GROUP_ID} isSpectator={false} />);
+    });
+
+  const clickMember2 = () =>
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="view-m2Doc"]')!
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+  beforeEach(() => {
+    state.updateViewTrackingFn = vi.fn(() => Promise.resolve());
+    state.viewTracking = {};
+    state.users = [me, freshMember2];
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("marks a member's log as viewed when it has unread posts", () => {
+    render();
+    clickMember2();
+
+    expect(state.updateViewTrackingFn).toHaveBeenCalledTimes(1);
+    expect(state.updateViewTrackingFn).toHaveBeenCalledWith({
+      userId: "meDoc",
+      logGroupId: GROUP_ID,
+      viewedUserId: "m2Doc",
+    });
+  });
+
+  it("does not write when the user is already caught up on that member", () => {
+    state.viewTracking = { [GROUP_ID]: { m2Doc: { lastViewedAt: { seconds: 2000 } } } };
+    render();
+    clickMember2();
+
+    expect(state.updateViewTrackingFn).not.toHaveBeenCalled();
+  });
+
+  it("does not write again while a previous mark-as-viewed is still pending", () => {
+    // Firestore surfaces the not-yet-acked serverTimestamp() as null.
+    state.viewTracking = { [GROUP_ID]: { m2Doc: { lastViewedAt: null } } };
+    render();
+    clickMember2();
+
+    expect(state.updateViewTrackingFn).not.toHaveBeenCalled();
+  });
+
+  it("never writes for the user's own log", () => {
+    render();
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="view-meDoc"]')!
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(state.updateViewTrackingFn).not.toHaveBeenCalled();
+  });
+
+  // The regression. Tapping a member during the cache-paint window used to skip the
+  // write — lastUpdated is absent, so the guard reads "nothing new" — and the effect
+  // never retried once the real snapshot arrived, leaving the bell lit on a log the
+  // user had already read.
+  it("retries the write when the real member snapshot lands after a cached paint", () => {
+    state.users = [me, cachedMember2];
+    render();
+    clickMember2();
+
+    // Cached members carry no lastUpdated, so there is nothing to mark as read yet.
+    expect(state.updateViewTrackingFn).not.toHaveBeenCalled();
+
+    // The Firestore listener fires with the real member docs. displayUser is unchanged,
+    // so only the `members` dependency can drive the retry.
+    state.users = [me, freshMember2];
+    render();
+
+    expect(state.updateViewTrackingFn).toHaveBeenCalledTimes(1);
+    expect(state.updateViewTrackingFn).toHaveBeenCalledWith({
+      userId: "meDoc",
+      logGroupId: GROUP_ID,
+      viewedUserId: "m2Doc",
+    });
+  });
+});

--- a/src/utils/__tests__/unread.test.ts
+++ b/src/utils/__tests__/unread.test.ts
@@ -52,6 +52,38 @@ describe("memberHasUnreadPosts", () => {
       }),
     ).toBe(false);
   });
+
+  // Firestore reads back a not-yet-acked serverTimestamp() as null. The entry existing
+  // means we already marked this viewed, so the bell must not flash back on while the
+  // write is in flight — the window is long enough to see on mobile.
+  it("is false while our mark-as-viewed write is still pending", () => {
+    expect(
+      memberHasUnreadPosts({
+        ...base,
+        viewTracking: { [GROUP]: { m1: { lastViewedAt: null } } },
+      }),
+    ).toBe(false);
+  });
+
+  it("distinguishes a pending write from never having viewed the member", () => {
+    expect(
+      memberHasUnreadPosts({ ...base, viewTracking: { [GROUP]: { m1: { lastViewedAt: null } } } }),
+    ).toBe(false);
+    // No entry at all for m1: genuinely never viewed, so the bell belongs on.
+    expect(memberHasUnreadPosts({ ...base, viewTracking: { [GROUP]: {} } })).toBe(true);
+  });
+
+  it("shows the bell again once a pending write resolves and a newer post arrives", () => {
+    // Write acked at t=100, then the member posts at t=150.
+    const member = { id: "m1", lastUpdated: { [GROUP]: ts(150) } };
+    expect(
+      memberHasUnreadPosts({
+        member,
+        groupId: GROUP,
+        viewTracking: { [GROUP]: { m1: { lastViewedAt: ts(100) } } },
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("commentsAreUnseen", () => {
@@ -74,6 +106,12 @@ describe("commentsAreUnseen", () => {
   it("is false when the last view is at or after the latest comment", () => {
     expect(commentsAreUnseen(post, { p1: { lastViewedAt: ts(100) } })).toBe(false);
     expect(commentsAreUnseen(post, { p1: { lastViewedAt: ts(150) } })).toBe(false);
+  });
+
+  it("is false while our mark-as-viewed write is still pending", () => {
+    expect(commentsAreUnseen(post, { p1: { lastViewedAt: null } })).toBe(false);
+    // Distinct from having no subscription entry at all, which is genuinely unseen.
+    expect(commentsAreUnseen(post, {})).toBe(true);
   });
 });
 
@@ -115,6 +153,11 @@ describe("postHasUnreadComments", () => {
 
   it("is false when subscribed but already caught up", () => {
     const user = { id: "u1", commentSubscriptions: { p1: { lastViewedAt: ts(100) } } };
+    expect(postHasUnreadComments(subscribedPost, user)).toBe(false);
+  });
+
+  it("is false while the mark-as-viewed write for that post is pending", () => {
+    const user = { id: "u1", commentSubscriptions: { p1: { lastViewedAt: null } } };
     expect(postHasUnreadComments(subscribedPost, user)).toBe(false);
   });
 

--- a/src/utils/unread.ts
+++ b/src/utils/unread.ts
@@ -4,9 +4,20 @@
 
 type TimestampLike = { seconds: number };
 
-type ViewTracking = Record<string, Record<string, { lastViewedAt?: TimestampLike } | undefined>>;
+// Firestore resolves a serverTimestamp() to `null` in local snapshots until the server
+// acks the write (SnapshotOptions.serverTimestamps defaults to 'none'). So a pending
+// mark-as-viewed reads back as `{ lastViewedAt: null }` for as long as the write is in
+// flight — long enough to see on a slow mobile connection, indefinitely while offline.
+type ViewEntry = { lastViewedAt?: TimestampLike | null } | undefined;
 
-type CommentSubscriptions = Record<string, { lastViewedAt?: TimestampLike } | undefined>;
+type ViewTracking = Record<string, Record<string, ViewEntry>>;
+
+type CommentSubscriptions = Record<string, ViewEntry>;
+
+// An in-flight mark-as-viewed write. The entry exists, so we have already decided this
+// was read; only the timestamp hasn't landed. Treating it as unviewed makes the badge
+// reappear the moment the item stops being suppressed.
+const isPendingWrite = (entry: ViewEntry): boolean => !!entry && entry.lastViewedAt === null;
 
 type UnreadMember = { id: string; lastUpdated?: Record<string, TimestampLike | undefined> };
 
@@ -31,7 +42,9 @@ export const memberHasUnreadPosts = ({
   if (!member) return false;
   const memberLastUpdated = member.lastUpdated?.[groupId];
   if (!memberLastUpdated) return false;
-  const lastViewedAt = viewTracking?.[groupId]?.[member.id]?.lastViewedAt;
+  const entry = viewTracking?.[groupId]?.[member.id];
+  if (isPendingWrite(entry)) return false;
+  const lastViewedAt = entry?.lastViewedAt;
   if (!lastViewedAt) return true;
   return memberLastUpdated.seconds > lastViewedAt.seconds;
 };
@@ -44,7 +57,9 @@ export const commentsAreUnseen = (
   commentSubscriptions: CommentSubscriptions | undefined,
 ): boolean => {
   if (!post?.latestCommentAt) return false;
-  const lastViewedAt = commentSubscriptions?.[post.id]?.lastViewedAt;
+  const entry = commentSubscriptions?.[post.id];
+  if (isPendingWrite(entry)) return false;
+  const lastViewedAt = entry?.lastViewedAt;
   if (!lastViewedAt) return true;
   return post.latestCommentAt.seconds > lastViewedAt.seconds;
 };


### PR DESCRIPTION
The post bell could stay lit on a member's log the user had already read. Two independent causes, both far more likely on mobile:

1. Group's view-tracking effect skipped the lastViewedAt write when the member snapshot hadn't landed yet. useGetGroupUsers paints from a localStorage cache whose CacheableUserData omits `lastUpdated`, and it sets isLoading false on the cache hit, so the nav is tappable while every member still looks like "nothing new". The effect's deps only tracked ids, so it never retried once the real snapshot arrived and the write was lost for good. Add `members` and `userIdToDocRefMap` to the deps. The window is wide on mobile: log posts need one round trip, group users need two (group doc, then the chunked user query).

2. memberHasUnreadPosts treated a pending serverTimestamp() as unread. Firestore resolves an un-acked server timestamp to null in local snapshots, and `if (!lastViewedAt) return true` counted that as never viewed, so the bell came back for the duration of the write. Now a present-but-null entry means "already marked read, timestamp in flight"; only a missing entry means never viewed. Same treatment for commentsAreUnseen, which is fed by the same kind of write.

The two fixes depend on each other: the new deps make the effect re-run more often, and (2) is what stops those re-runs from queueing duplicate writes.

Tests: new Group.viewTracking suite renders the real component and covers the cache-then-snapshot retry, the pending-write dedupe, already-caught-up, and own-log cases; unread gains cases for pending vs. missing entries. Each fix was confirmed to be load-bearing by reverting it and watching the corresponding tests fail.